### PR TITLE
WID-213 - added new setting items (integer) in SearchResults.php

### DIFF
--- a/src/Widget/WidgetType/SearchResults.php
+++ b/src/Widget/WidgetType/SearchResults.php
@@ -40,7 +40,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *              },
  *              "labels_as_icons":{
  *                  "enabled":false
- *              }
+ *              },
+ *              "items": 10
  *          },
  *          "header":{
  *              "body":"",
@@ -196,7 +197,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
  *              },
  *              "labels_as_icons":{
  *                  "enabled":"boolean"
- *              }
+ *              },
+ *              "items":"integer"
  *          },
  *          "header":{
  *              "body":"string"
@@ -438,7 +440,8 @@ class SearchResults extends WidgetTypeBase
         // Pagination settings.
         $currentPageIndex = 0;
         // Limit items per page.
-        $query->setLimit(self::ITEMS_PER_PAGE);
+        $results_per_page = $this->settings['general']['items'] ?: self::ITEMS_PER_PAGE;
+        $query->setLimit($results_per_page);
 
         $extraFilters = [];
         // Change query / defaults based on query string.
@@ -449,7 +452,7 @@ class SearchResults extends WidgetTypeBase
                 // Set current page index.
                 $currentPageIndex = $searchResultOptions['page'];
                 // Move start according to the active page.
-                $query->setStart($currentPageIndex * self::ITEMS_PER_PAGE);
+                $query->setStart($currentPageIndex * $results_per_page);
             }
 
             if (!empty($searchResultOptions['hide-long-term'])) {

--- a/src/Widget/WidgetType/SearchResults.php
+++ b/src/Widget/WidgetType/SearchResults.php
@@ -440,8 +440,8 @@ class SearchResults extends WidgetTypeBase
         // Pagination settings.
         $currentPageIndex = 0;
         // Limit items per page.
-        $results_per_page = $this->settings['general']['items'] ?: self::ITEMS_PER_PAGE;
-        $query->setLimit($results_per_page);
+        $resultsPerPage = $this->settings['general']['items'] ?: self::ITEMS_PER_PAGE;
+        $query->setLimit($resultsPerPage);
 
         $extraFilters = [];
         // Change query / defaults based on query string.
@@ -452,7 +452,7 @@ class SearchResults extends WidgetTypeBase
                 // Set current page index.
                 $currentPageIndex = $searchResultOptions['page'];
                 // Move start according to the active page.
-                $query->setStart($currentPageIndex * $results_per_page);
+                $query->setStart($currentPageIndex * $resultsPerPage);
             }
 
             if (!empty($searchResultOptions['hide-long-term'])) {


### PR DESCRIPTION
### Added
- added new setting in searchResults.php annotations so it accepts the setting "items" (integer). So the user can decide how many items he wants to show on the page.
- added new variable $results_per_page which will have the value of the items settings (if it exists) otherwise it will take the const ITEMS_PER_PAGE (which is set to 10).

### Changed
- the query->setLimit now uses the $results_per_page param
- the query->setStart now uses the $results_per_page param