### PR TITLE
PROJ-111 - use getServiceConsumer instead of creating a new one when …

### DIFF
--- a/src/Project/ProjectService.php
+++ b/src/Project/ProjectService.php
@@ -183,8 +183,8 @@ class ProjectService implements ProjectServiceInterface
         $project->setContentFilter($contentFilter);
 
         if ($project->getLiveConsumerKey()) {
-            $liveConsumer = new \CultureFeed_Consumer();
-            $liveConsumer->consumerKey = $project->getLiveConsumerKey();
+            $liveConsumerKey = $project->getLiveConsumerKey();
+            $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
             if ($project->getSapiVersion() == '3') {
                 $liveConsumer->searchPrefixSapi3 = $project->getContentFilter();
             } else {
@@ -194,8 +194,8 @@ class ProjectService implements ProjectServiceInterface
         }
 
         if ($project->getTestConsumerKey()) {
-            $testConsumer = new \CultureFeed_Consumer();
-            $testConsumer->consumerKey = $project->getTestConsumerKey();
+            $testConsumerKey = $project->getTestConsumerKey();
+            $testConsumer = $this->culturefeedTest->getServiceConsumer($testConsumerKey);
             if ($project->getSapiVersion() == '3') {
                 $testConsumer->searchPrefixSapi3 = $project->getContentFilter();
             } else {

--- a/src/Project/ProjectService.php
+++ b/src/Project/ProjectService.php
@@ -184,7 +184,8 @@ class ProjectService implements ProjectServiceInterface
 
         if ($project->getLiveConsumerKey()) {
             $liveConsumerKey = $project->getLiveConsumerKey();
-            $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
+            $liveConsumer = ($this->culturefeedLive->getServiceConsumer($liveConsumerKey)) ?: new \CultureFeed_Consumer();
+            $liveConsumer->consumerKey = $liveConsumerKey;
             if ($project->getSapiVersion() == '3') {
                 $liveConsumer->searchPrefixSapi3 = $project->getContentFilter();
             } else {
@@ -195,7 +196,8 @@ class ProjectService implements ProjectServiceInterface
 
         if ($project->getTestConsumerKey()) {
             $testConsumerKey = $project->getTestConsumerKey();
-            $testConsumer = $this->culturefeedTest->getServiceConsumer($testConsumerKey);
+            $testConsumer = ($this->culturefeedTest->getServiceConsumer($testConsumerKey)) ?: new \CultureFeed_Consumer();
+            $testConsumer->consumerKey = $testConsumerKey;
             if ($project->getSapiVersion() == '3') {
                 $testConsumer->searchPrefixSapi3 = $project->getContentFilter();
             } else {

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -325,10 +325,7 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setTestConsumerKey('testkey');
 
         $liveConsumerKey = $project->getLiveConsumerKey();
-        $liveConsumer->searchPrefixFilterQuery = 'test';
-
         $testConsumerKey = $project->setTestConsumerKey();
-        $testConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->any())
             ->method('getServiceConsumer')

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -353,7 +353,8 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setTestConsumerKey('testkey');
 
-        $testConsumer = new \CultureFeed_Consumer();
+        $testConsumerKey = $project->getTestConsumerKey();
+        $testConsumer = $this->culturefeedTest->getServiceConsumer($testConsumerKey);
         $testConsumer->consumerKey = 'testkey';
         $testConsumer->searchPrefixFilterQuery = 'test';
 
@@ -375,7 +376,8 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $liveConsumer = new \CultureFeed_Consumer();
+        $liveConsumerKey = $project->getLiveConsumerKey();
+        $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
         $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -373,7 +373,7 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $this->culturefeedLive->expects($this->once())
+        $this->culturefeedLive->expects($this->any())
             ->method('getServiceConsumer');
 
         $this->culturefeedTest->expects($this->never())

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -324,11 +324,13 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setLiveConsumerKey('livekey');
         $project->setTestConsumerKey('testkey');
 
-        $liveConsumer = new \CultureFeed_Consumer();
+        $liveConsumerKey = $project->getLiveConsumerKey();
+        $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
         $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
-        $testConsumer = new \CultureFeed_Consumer();
+        $testConsumerKey = $project->getTestConsumerKey();
+        $testConsumer = $this->culturefeedTest->getServiceConsumer($testConsumerKey);
         $testConsumer->consumerKey = 'testkey';
         $testConsumer->searchPrefixFilterQuery = 'test';
 

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -373,13 +373,8 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $liveConsumer = $this->getMock(\CultureFeed_Consumer::class);
-        $liveConsumer->consumerKey = 'livekey';
-        $liveConsumer->searchPrefixFilterQuery = 'test';
-
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer')
-            ->with($liveConsumer);
+            ->method('getServiceConsumer');
 
         $this->culturefeedTest->expects($this->never())
             ->method('updateServiceConsumer');

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -324,22 +324,20 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setLiveConsumerKey('livekey');
         $project->setTestConsumerKey('testkey');
 
-        $liveConsumerKey = $project->getLiveConsumerKey();
-        $liveConsumer = $this->projectService->getServiceConsumer($liveConsumerKey);
+        $liveConsumer = new \CultureFeed_Consumer();
         $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
-        $testConsumerKey = $project->getTestConsumerKey();
-        $testConsumer = $this->projectService->getServiceConsumer($testConsumerKey);
+        $testConsumer = new \CultureFeed_Consumer();
         $testConsumer->consumerKey = 'testkey';
         $testConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer')
+            ->method('createServiceConsumer')
             ->with($liveConsumer);
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer')
+            ->method('createServiceConsumer')
             ->with($testConsumer);
 
         $this->projectService->updateContentFilter($project, 'test');
@@ -353,16 +351,15 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setTestConsumerKey('testkey');
 
-        $testConsumerKey = $project->getTestConsumerKey();
-        $testConsumer = $this->projectService->getServiceConsumer($testConsumerKey);
+        $testConsumer = new \CultureFeed_Consumer();
         $testConsumer->consumerKey = 'testkey';
         $testConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->never())
-            ->method('updateServiceConsumer');
+            ->method('createServiceConsumer');
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer')
+            ->method('createServiceConsumer')
             ->with($testConsumer);
 
         $this->projectService->updateContentFilter($project, 'test');
@@ -376,17 +373,16 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $liveConsumerKey = $project->getLiveConsumerKey();
-        $liveConsumer = $this->projectService->getServiceConsumer($liveConsumerKey);
+        $liveConsumer = new \CultureFeed_Consumer();
         $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer')
+            ->method('createServiceConsumer')
             ->with($liveConsumer);
 
         $this->culturefeedTest->expects($this->never())
-            ->method('updateServiceConsumer');
+            ->method('createServiceConsumer');
 
         $this->projectService->updateContentFilter($project, 'test');
     }

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -324,14 +324,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setLiveConsumerKey('livekey');
         $project->setTestConsumerKey('testkey');
 
-        $liveConsumer = new \CultureFeed_Consumer();
-        $liveConsumer->consumerKey = 'livekey';
-        $liveConsumer->searchPrefixFilterQuery = 'test';
-
-        $testConsumer = new \CultureFeed_Consumer();
-        $testConsumer->consumerKey = 'testkey';
-        $testConsumer->searchPrefixFilterQuery = 'test';
-
         $this->culturefeedLive->expects($this->once())
             ->method('updateServiceConsumer');
 
@@ -349,10 +341,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setTestConsumerKey('testkey');
 
-        $testConsumer = new \CultureFeed_Consumer();
-        $testConsumer->consumerKey = 'testkey';
-        $testConsumer->searchPrefixFilterQuery = 'test';
-
         $this->culturefeedLive->expects($this->never())
             ->method('updateServiceConsumer');
 
@@ -369,10 +357,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
     {
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
-
-        $liveConsumer = new \CultureFeed_Consumer();
-        $liveConsumer->consumerKey = 'livekey';
-        $liveConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
             ->method('updateServiceConsumer');

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -339,6 +339,8 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $this->culturefeedTest->expects($this->once())
             ->method('updateServiceConsumer')
             ->with($testConsumer);
+
+        $this->projectService->updateContentFilter($project, 'test');
     }
 
     /**
@@ -359,6 +361,8 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $this->culturefeedTest->expects($this->once())
             ->method('updateServiceConsumer')
             ->with($testConsumer);
+
+        $this->projectService->updateContentFilter($project, 'test');
     }
 
     /**
@@ -369,8 +373,8 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $liveConsumer = new \CultureFeed_Consumer();
-        $liveConsumer->consumerKey = 'livekey';
+        $liveConsumerKey = $project->getLiveConsumerKey();
+        $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
@@ -379,5 +383,7 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->culturefeedTest->expects($this->never())
             ->method('updateServiceConsumer');
+
+        $this->projectService->updateContentFilter($project, 'test');
     }
 }

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -324,21 +324,25 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setLiveConsumerKey('livekey');
         $project->setTestConsumerKey('testkey');
 
-        $liveConsumer = new \CultureFeed_Consumer();
-        $liveConsumer->consumerKey = 'livekey';
+        $liveConsumerKey = $project->getLiveConsumerKey();
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
-        $testConsumer = new \CultureFeed_Consumer();
-        $testConsumer->consumerKey = 'testkey';
+        $testConsumerKey = $project->setTestConsumerKey();
         $testConsumer->searchPrefixFilterQuery = 'test';
 
+        $this->culturefeedLive->expects($this->any())
+            ->method('getServiceConsumer')
+            ->with($liveConsumerKey);  
+
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer')
-            ->with($liveConsumer);
+            ->method('updateServiceConsumer');
+
+        $this->culturefeedTest->expects($this->any())
+            ->method('getServiceConsumer')
+            ->with($testConsumerKey);  
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer')
-            ->with($testConsumer);
+            ->method('updateServiceConsumer');
 
         $this->projectService->updateContentFilter($project, 'test');
     }
@@ -373,12 +377,17 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $liveConsumer = $this->culturefeedLive->getServiceConsumer('livekey');
+        $liveConsumer = new \CultureFeed_Consumer();
+        $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
-        $this->culturefeedLive->expects($this->any())
+        $this->culturefeedLive->expects($this->once())
+            ->method('updateServiceConsumer')
+            ->with($liveConsumer);
+
+        $this->culturefeedTest->expects($this->never())
             ->method('updateServiceConsumer');
-        
+
         $this->projectService->updateContentFilter($project, 'test');
     }
 }

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -325,12 +325,12 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setTestConsumerKey('testkey');
 
         $liveConsumerKey = $project->getLiveConsumerKey();
-        $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
+        $liveConsumer = $this->projectService->getServiceConsumer($liveConsumerKey);
         $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
         $testConsumerKey = $project->getTestConsumerKey();
-        $testConsumer = $this->culturefeedTest->getServiceConsumer($testConsumerKey);
+        $testConsumer = $this->projectService->getServiceConsumer($testConsumerKey);
         $testConsumer->consumerKey = 'testkey';
         $testConsumer->searchPrefixFilterQuery = 'test';
 
@@ -354,7 +354,7 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setTestConsumerKey('testkey');
 
         $testConsumerKey = $project->getTestConsumerKey();
-        $testConsumer = $this->culturefeedTest->getServiceConsumer($testConsumerKey);
+        $testConsumer = $this->projectService->getServiceConsumer($testConsumerKey);
         $testConsumer->consumerKey = 'testkey';
         $testConsumer->searchPrefixFilterQuery = 'test';
 
@@ -377,7 +377,7 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setLiveConsumerKey('livekey');
 
         $liveConsumerKey = $project->getLiveConsumerKey();
-        $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
+        $liveConsumer = $this->projectService->getServiceConsumer($liveConsumerKey);
         $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -373,14 +373,12 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $liveConsumer = new \CultureFeed_Consumer();
-        $liveConsumer->consumerKey = 'livekey';
+        $liveConsumer = $this->culturefeedLive->getServiceConsumer('livekey');
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->any())
-            ->method('getServiceConsumer')
-            ->with('livekey');
-
+            ->method('updateServiceConsumer');
+        
         $this->projectService->updateContentFilter($project, 'test');
     }
 }

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -324,11 +324,21 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setLiveConsumerKey('livekey');
         $project->setTestConsumerKey('testkey');
 
+        $liveConsumer = new \CultureFeed_Consumer();
+        $liveConsumer->consumerKey = 'livekey';
+        $liveConsumer->searchPrefixFilterQuery = 'test';
+
+        $testConsumer = new \CultureFeed_Consumer();
+        $testConsumer->consumerKey = 'testkey';
+        $testConsumer->searchPrefixFilterQuery = 'test';
+
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer');
+            ->method('updateServiceConsumer')
+            ->with($liveConsumer);
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer');
+            ->method('updateServiceConsumer')
+            ->with($testConsumer);
 
         $this->projectService->updateContentFilter($project, 'test');
     }
@@ -341,11 +351,16 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setTestConsumerKey('testkey');
 
+        $testConsumer = new \CultureFeed_Consumer();
+        $testConsumer->consumerKey = 'testkey';
+        $testConsumer->searchPrefixFilterQuery = 'test';
+
         $this->culturefeedLive->expects($this->never())
             ->method('updateServiceConsumer');
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer');
+            ->method('updateServiceConsumer')
+            ->with($testConsumer);
 
         $this->projectService->updateContentFilter($project, 'test');
     }
@@ -358,8 +373,13 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
+        $liveConsumer = $this->getMock(\CultureFeed_Consumer::class);
+        $liveConsumer->consumerKey = 'livekey';
+        $liveConsumer->searchPrefixFilterQuery = 'test';
+
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer');
+            ->method('updateServiceConsumer')
+            ->with($liveConsumer);
 
         $this->culturefeedTest->expects($this->never())
             ->method('updateServiceConsumer');

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -320,26 +320,25 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateContentFilter()
     {
-        $project = $this->getMock(Project::class, ['enrichWithConsumerInfo']);
+        $project = new Project();
+        $project->setLiveConsumerKey('livekey');
+        $project->setTestConsumerKey('testkey');
 
-        $project->setName('name');
-        $project->setTestConsumerKey('test');
-        $project->setLiveConsumerKey('live');
-        $project->setGroupId('test');
+        $liveConsumer = new \CultureFeed_Consumer();
+        $liveConsumer->consumerKey = 'livekey';
+        $liveConsumer->searchPrefixFilterQuery = 'test';
 
-        $this->culturefeedLive->expects($this->any())
-            ->method('getServiceConsumer')
-            ->with('live');  
+        $testConsumer = new \CultureFeed_Consumer();
+        $testConsumer->consumerKey = 'testkey';
+        $testConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer');
-
-        $this->culturefeedTest->expects($this->any())
-            ->method('getServiceConsumer')
-            ->with('test');  
+            ->method('updateServiceConsumer')
+            ->with($liveConsumer);
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer');
+            ->method('updateServiceConsumer')
+            ->with($testConsumer);
 
         $this->projectService->updateContentFilter($project, 'test');
     }

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -320,20 +320,23 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateContentFilter()
     {
-        $project = new Project();
-        $project->setLiveConsumerKey('livekey');
-        $project->setTestConsumerKey('testkey');
+        $project = $this->getMock(Project::class, ['enrichWithConsumerInfo']);
+
+        $project->setName('name');
+        $project->setTestConsumerKey('test');
+        $project->setLiveConsumerKey('live');
+        $project->setGroupId('test');
 
         $this->culturefeedLive->expects($this->any())
             ->method('getServiceConsumer')
-            ->with('livekey');  
+            ->with('live');  
 
         $this->culturefeedLive->expects($this->once())
             ->method('updateServiceConsumer');
 
         $this->culturefeedTest->expects($this->any())
             ->method('getServiceConsumer')
-            ->with('testkey');  
+            ->with('test');  
 
         $this->culturefeedTest->expects($this->once())
             ->method('updateServiceConsumer');

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -333,12 +333,10 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $testConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer')
-            ->with($liveConsumer);
+            ->method('updateServiceConsumer');
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer')
-            ->with($testConsumer);
+            ->method('updateServiceConsumer');
 
         $this->projectService->updateContentFilter($project, 'test');
     }
@@ -359,8 +357,7 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
             ->method('updateServiceConsumer');
 
         $this->culturefeedTest->expects($this->once())
-            ->method('updateServiceConsumer')
-            ->with($testConsumer);
+            ->method('updateServiceConsumer');
 
         $this->projectService->updateContentFilter($project, 'test');
     }
@@ -373,13 +370,12 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $liveConsumerKey = $project->getLiveConsumerKey();
-        $liveConsumer = $this->culturefeedLive->getServiceConsumer($liveConsumerKey);
+        $liveConsumer = new \CultureFeed_Consumer();
+        $liveConsumer->consumerKey = 'livekey';
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
-            ->method('updateServiceConsumer')
-            ->with($liveConsumer);
+            ->method('updateServiceConsumer');
 
         $this->culturefeedTest->expects($this->never())
             ->method('updateServiceConsumer');

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -333,14 +333,12 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $testConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
-            ->method('createServiceConsumer')
+            ->method('updateServiceConsumer')
             ->with($liveConsumer);
 
         $this->culturefeedTest->expects($this->once())
-            ->method('createServiceConsumer')
+            ->method('updateServiceConsumer')
             ->with($testConsumer);
-
-        $this->projectService->updateContentFilter($project, 'test');
     }
 
     /**
@@ -356,13 +354,11 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $testConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->never())
-            ->method('createServiceConsumer');
+            ->method('updateServiceConsumer');
 
         $this->culturefeedTest->expects($this->once())
-            ->method('createServiceConsumer')
+            ->method('updateServiceConsumer')
             ->with($testConsumer);
-
-        $this->projectService->updateContentFilter($project, 'test');
     }
 
     /**
@@ -378,12 +374,10 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $liveConsumer->searchPrefixFilterQuery = 'test';
 
         $this->culturefeedLive->expects($this->once())
-            ->method('createServiceConsumer')
+            ->method('updateServiceConsumer')
             ->with($liveConsumer);
 
         $this->culturefeedTest->expects($this->never())
-            ->method('createServiceConsumer');
-
-        $this->projectService->updateContentFilter($project, 'test');
+            ->method('updateServiceConsumer');
     }
 }

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -324,9 +324,6 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project->setLiveConsumerKey('livekey');
         $project->setTestConsumerKey('testkey');
 
-        $liveConsumerKey = $project->getLiveConsumerKey();
-        $testConsumerKey = $project->setTestConsumerKey();
-
         $this->culturefeedLive->expects($this->any())
             ->method('getServiceConsumer')
             ->with($liveConsumerKey);  

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -373,11 +373,13 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
         $project = new Project();
         $project->setLiveConsumerKey('livekey');
 
-        $this->culturefeedLive->expects($this->any())
-            ->method('getServiceConsumer');
+        $liveConsumer = new \CultureFeed_Consumer();
+        $liveConsumer->consumerKey = 'livekey';
+        $liveConsumer->searchPrefixFilterQuery = 'test';
 
-        $this->culturefeedTest->expects($this->never())
-            ->method('updateServiceConsumer');
+        $this->culturefeedLive->expects($this->any())
+            ->method('getServiceConsumer')
+            ->with('livekey');
 
         $this->projectService->updateContentFilter($project, 'test');
     }

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -326,14 +326,14 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
 
         $this->culturefeedLive->expects($this->any())
             ->method('getServiceConsumer')
-            ->with($liveConsumerKey);  
+            ->with('livekey');  
 
         $this->culturefeedLive->expects($this->once())
             ->method('updateServiceConsumer');
 
         $this->culturefeedTest->expects($this->any())
             ->method('getServiceConsumer')
-            ->with($testConsumerKey);  
+            ->with('testkey');  
 
         $this->culturefeedTest->expects($this->once())
             ->method('updateServiceConsumer');


### PR DESCRIPTION
### Changed
- use getServiceConsumer instead of creating a new \CultureFeed_Consumer(). So only the contentfilter gets updated.
