### PR TITLE
Feature/proj 121

### DIFF
--- a/app/ApplicationBase.php
+++ b/app/ApplicationBase.php
@@ -150,7 +150,7 @@ class ApplicationBase extends SilexApplication
             new CuratorenAPIServiceProvider(),
             [
                 'curatoren_api.base_url' => $this['config']['curatoren_api']['live']['base_url'],
-                'curatoren_api.base_url' => $this['config']['curatoren_api']['test']['base_url'],
+                'curatoren_api_test.base_url' => $this['config']['curatoren_api']['test']['base_url'],
                 'curatoren_api.cache.enabled' => $this['config']['curatoren_api']['cache']['enabled'],
                 'curatoren_api.cache.backend' => $this['config']['curatoren_api']['cache']['backend'],
                 'curatoren_api.cache.ttl' => $this['config']['curatoren_api']['cache']['ttl'],
@@ -162,7 +162,7 @@ class ApplicationBase extends SilexApplication
             new ArticleLinkerAPIServiceProvider(),
             [
                 'articlelinker_api.base_url' => $this['config']['articlelinker_api']['live']['base_url'],
-                'articlelinker_api.base_url' => $this['config']['articlelinker_api']['test']['base_url'],
+                'articlelinker_api_test.base_url' => $this['config']['articlelinker_api']['test']['base_url'],
                 'articlelinker_api.cache.enabled' => $this['config']['articlelinker_api']['cache']['enabled'],
                 'articlelinker_api.cache.backend' => $this['config']['articlelinker_api']['cache']['backend'],
                 'articlelinker_api.cache.ttl' => $this['config']['articlelinker_api']['cache']['ttl'],

--- a/app/Widget/WidgetServiceProvider.php
+++ b/app/Widget/WidgetServiceProvider.php
@@ -68,7 +68,7 @@ class WidgetServiceProvider implements ServiceProviderInterface
 
             /** @var RequestContext $requestContext */
             $requestContext = $pimple['request_context'];
-            $renderer = new Renderer($pimple['widget_layout_manager'], $pimple['google_tag_manager'], $pimple['project_repository'], $pimple['search_api'], $pimple['search_api_test']);
+            $renderer = new Renderer($pimple['widget_layout_manager'], $pimple['google_tag_manager'], $pimple['project_repository'], $pimple['search_api'], $pimple['search_api_test'], $pimple['curatoren_api'], $pimple['curatoren_api_test']);
             $renderer->addSettings(['apiUrl' => $requestContext->getScheme() . '://' . $requestContext->getHost() . $requestContext->getBaseUrl() . '/widgets/api']);
 
             return $renderer;

--- a/app/config/messagebus.yml
+++ b/app/config/messagebus.yml
@@ -25,6 +25,7 @@ listeners:
         class: \CultuurNet\ProjectAanvraag\ArticleLinker\EventListener\ArticleLinkCreatedEventListener
         arguments:
             - articlelinker_api
+            - articlelinker_api_test
             - articlelinker_cache
 
     project_created_listener:

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -93,9 +93,9 @@ curatoren_api:
 # Article Linker
 articlelinker_api:
   test:
-    base_url: https://curator-acc.uitdatabank.be/
+    base_url: https://articlelinker-acc.uitdatabank.be/
   live:
-    base_url: https://curator-acc.uitdatabank.be/
+    base_url: https://articlelinker.uitdatabank.be/
   cache:
     enabled: true
     backend: redis

--- a/src/ArticleLinker/ArticleLinkerClientInterface.php
+++ b/src/ArticleLinker/ArticleLinkerClientInterface.php
@@ -28,6 +28,7 @@ interface ArticleLinkerClientInterface
     /**
      * Link an article.
      *
+     * @param String $url
      * @param String $cdbid
      * @return Array
      */

--- a/src/ArticleLinker/Command/CreateArticleLink.php
+++ b/src/ArticleLinker/Command/CreateArticleLink.php
@@ -15,6 +15,12 @@ class CreateArticleLink
     private $cdbid;
 
     /**
+     * @var string
+     */
+    private $projectActive;
+
+
+    /**
      * CreateArticleLink constructor.
      * @param $url
      * @param $cdbid
@@ -49,6 +55,14 @@ class CreateArticleLink
     public function getCdbid()
     {
         return $this->cdbid;
+    }
+
+    /**
+     * @return Boolean
+     */
+    public function getProjectActive()
+    {
+        return $this->projectActive;
     }
 
     /**

--- a/src/ArticleLinker/CommandHandler/CreateArticleLinkCommandHandler.php
+++ b/src/ArticleLinker/CommandHandler/CreateArticleLinkCommandHandler.php
@@ -30,7 +30,7 @@ class CreateArticleLinkCommandHandler
      */
     public function handle(CreateArticleLink $createArticleLink)
     {
-        $articleLinkCreated = new ArticleLinkCreated($createArticleLink->getUrl(), $createArticleLink->getCdbid());
+        $articleLinkCreated = new ArticleLinkCreated($createArticleLink->getUrl(), $createArticleLink->getCdbid(), $createArticleLink->getProjectActive());
         $this->eventBus->handle($articleLinkCreated);
     }
 }

--- a/src/ArticleLinker/Event/ArticleLinkCreated.php
+++ b/src/ArticleLinker/Event/ArticleLinkCreated.php
@@ -21,14 +21,21 @@ class ArticleLinkCreated extends AbstractRetryableMessage
     private $url;
 
     /**
+     * @var string
+     * @Type("string")
+     */
+    private $projectActive;
+
+    /**
      * ArticleLinkCreated constructor.
      * @param string $url
      * @param string $cdbid
      */
-    public function __construct($url, $cdbid, $delay = 5)
+    public function __construct($url, $cdbid, $projectActive, $delay = 5)
     {
         $this->url = $url;
         $this->cdbid = $cdbid;
+        $this->projectActive = $projectActive;
         $this->delay = $delay;
     }
 
@@ -59,7 +66,7 @@ class ArticleLinkCreated extends AbstractRetryableMessage
     }
 
     /**
-     * @param string $usedCoupon
+     * @param string
      * @return ArticleLinkCreated
      */
     public function setCbid($cdbid)
@@ -67,4 +74,13 @@ class ArticleLinkCreated extends AbstractRetryableMessage
         $this->cdbid = $cdbid;
         return $this;
     }
+
+    /**
+     * @return Boolean
+     */
+    public function getProjectActive()
+    {
+        return $this->projectActive;
+    }
+
 }

--- a/src/ArticleLinker/Event/ArticleLinkCreated.php
+++ b/src/ArticleLinker/Event/ArticleLinkCreated.php
@@ -82,5 +82,4 @@ class ArticleLinkCreated extends AbstractRetryableMessage
     {
         return $this->projectActive;
     }
-
 }

--- a/src/ArticleLinker/EventListener/ArticleLinkCreatedEventListener.php
+++ b/src/ArticleLinker/EventListener/ArticleLinkCreatedEventListener.php
@@ -11,7 +11,12 @@ class ArticleLinkCreatedEventListener
     /**
      * @var ArticleLinkerClientInterface
      */
-    protected $articleLinkerClient;
+    protected $articleLinkerClientLive;
+
+    /**
+     * @var ArticleLinkerClientInterface
+     */
+    protected $articleLinkerClientTest;
 
     /**
      * @var AbstractCache
@@ -23,9 +28,10 @@ class ArticleLinkCreatedEventListener
      * @param ArticleLinkerClientInterface $articleLinkerClient
      * @param AbstractCache $cacheBackend
      */
-    public function __construct(ArticleLinkerClientInterface $articleLinkerClient, $cacheBackend = null)
+    public function __construct(ArticleLinkerClientInterface $articleLinkerClientLive,ArticleLinkerClientInterface $articleLinkerClientTest, $cacheBackend = null)
     {
-        $this->articleLinkerClient = $articleLinkerClient;
+        $this->articleLinkerClientLive = $articleLinkerClientLive;
+        $this->articleLinkerClientTest = $articleLinkerClientTest;
         $this->cacheBackend = $cacheBackend;
     }
 
@@ -38,12 +44,16 @@ class ArticleLinkCreatedEventListener
     {
         $url = $articleLinkCreated->getUrl();
         $cdbid = $articleLinkCreated->getCdbid();
+        $projectActive = $articleLinkCreated->getProjectActive();
 
         $cacheId = md5($url . ':' . $cdbid);
         if ($this->cacheBackend) {
             if (!$this->cacheBackend->has($cacheId)) {
-                $this->articleLinkerClient->linkArticle($url, $cdbid);
-
+                if($projectActive){
+                  $this->articleLinkerClientLive->linkArticle($url, $cdbid);
+                }else{
+                  $this->articleLinkerClientTest->linkArticle($url, $cdbid);
+                }
                 $this->cacheBackend->set(
                     $cacheId,
                     [

--- a/src/ArticleLinker/EventListener/ArticleLinkCreatedEventListener.php
+++ b/src/ArticleLinker/EventListener/ArticleLinkCreatedEventListener.php
@@ -46,14 +46,16 @@ class ArticleLinkCreatedEventListener
         $cdbid = $articleLinkCreated->getCdbid();
         $projectActive = $articleLinkCreated->getProjectActive();
 
+        if ($projectActive) {
+          $articleLinkerClient =  $this->articleLinkerClientLive;
+        } else {
+          $articleLinkerClient =  $this->articleLinkerClientTest;
+        } 
+
         $cacheId = md5($url . ':' . $cdbid);
         if ($this->cacheBackend) {
             if (!$this->cacheBackend->has($cacheId)) {
-                if($projectActive){
-                  $this->articleLinkerClientLive->linkArticle($url, $cdbid);
-                }else{
-                  $this->articleLinkerClientTest->linkArticle($url, $cdbid);
-                }
+                $articleLinkerClient->linkArticle($url, $cdbid);
                 $this->cacheBackend->set(
                     $cacheId,
                     [
@@ -63,7 +65,7 @@ class ArticleLinkCreatedEventListener
                 );
             }
         } else {
-            $this->articleLinkerClient->linkArticle($url, $cdbid);
+            $articleLinkerClient->linkArticle($url, $cdbid);
         }
     }
 }

--- a/src/ArticleLinker/EventListener/ArticleLinkCreatedEventListener.php
+++ b/src/ArticleLinker/EventListener/ArticleLinkCreatedEventListener.php
@@ -28,7 +28,7 @@ class ArticleLinkCreatedEventListener
      * @param ArticleLinkerClientInterface $articleLinkerClient
      * @param AbstractCache $cacheBackend
      */
-    public function __construct(ArticleLinkerClientInterface $articleLinkerClientLive,ArticleLinkerClientInterface $articleLinkerClientTest, $cacheBackend = null)
+    public function __construct(ArticleLinkerClientInterface $articleLinkerClientLive, ArticleLinkerClientInterface $articleLinkerClientTest, $cacheBackend = null)
     {
         $this->articleLinkerClientLive = $articleLinkerClientLive;
         $this->articleLinkerClientTest = $articleLinkerClientTest;
@@ -47,10 +47,10 @@ class ArticleLinkCreatedEventListener
         $projectActive = $articleLinkCreated->getProjectActive();
 
         if ($projectActive) {
-          $articleLinkerClient =  $this->articleLinkerClientLive;
+            $articleLinkerClient = $this->articleLinkerClientLive;
         } else {
-          $articleLinkerClient =  $this->articleLinkerClientTest;
-        } 
+            $articleLinkerClient = $this->articleLinkerClientTest;
+        }
 
         $cacheId = md5($url . ':' . $cdbid);
         if ($this->cacheBackend) {

--- a/src/Widget/Controller/WidgetController.php
+++ b/src/Widget/Controller/WidgetController.php
@@ -3,6 +3,8 @@
 namespace CultuurNet\ProjectAanvraag\Widget\Controller;
 
 use CultuurNet\ProjectAanvraag\Project\Converter\ProjectConverter;
+use CultuurNet\ProjectAanvraag\Entity\ProjectInterface;
+
 use CultuurNet\ProjectAanvraag\Widget\Entities\WidgetRowEntity;
 use CultuurNet\ProjectAanvraag\Widget\JavascriptResponse;
 use CultuurNet\ProjectAanvraag\Widget\LayoutManager;
@@ -161,12 +163,15 @@ class WidgetController
      */
     public function renderWidget(Request $request, WidgetPageInterface $widgetPage, $widgetId, $cdbid = '')
     {
+        $project = $this->projectConverter->convert($widgetPage->getProjectId());
+        $projectActive = $project->getStatus() === ProjectInterface::PROJECT_STATUS_ACTIVE;
+
         if ($cdbid && $request->headers->get('referer')) {
             $url = $request->headers->get('referer');
-            $this->commandBus->handle(new CreateArticleLink($url, $cdbid));
+           
+            $this->commandBus->handle(new CreateArticleLink($url, $cdbid, $projectActive));
         }
 
-        $project = $this->projectConverter->convert($widgetPage->getProjectId());
         if (!$project) {
             throw new NotFoundHttpException();
         }

--- a/src/Widget/Renderer.php
+++ b/src/Widget/Renderer.php
@@ -13,6 +13,7 @@ use CultuurNet\ProjectAanvraag\Widget\WidgetType\Html;
 use CultuurNet\ProjectAanvraag\Widget\WidgetType\SearchResults;
 use CultuurNet\SearchV3\SearchClient;
 use CultuurNet\SearchV3\SearchClientInterface;
+use CultuurNet\ProjectAanvraag\Curatoren\CuratorenClient;
 use Doctrine\ORM\EntityRepository;
 
 /**
@@ -53,6 +54,16 @@ class Renderer implements RendererInterface
     protected $searchClientTest;
 
     /**
+     * @var CuratorenClient
+     */
+    protected $curatorenClient;
+
+    /**
+     * @var CuratorenClient
+     */
+    protected $curatorenClientTest;
+
+    /**
      * @var array
      */
     private $jsFiles = [];
@@ -73,13 +84,15 @@ class Renderer implements RendererInterface
      * @param $googleTagManagerId
      * @param ProjectServiceInterface $projectService
      */
-    public function __construct(WidgetPluginManager $widgetPluginManager, $googleTagManagerId, EntityRepository $projectRepository, SearchClientInterface $searchClient, SearchClientInterface $searchClientTest)
+    public function __construct(WidgetPluginManager $widgetPluginManager, $googleTagManagerId, EntityRepository $projectRepository, SearchClientInterface $searchClient, SearchClientInterface $searchClientTest, CuratorenClient $curatorenClient, CuratorenClient $curatorenClientTest)
     {
         $this->widgetPluginManager = $widgetPluginManager;
         $this->googleTagManagerId = $googleTagManagerId;
         $this->projectRepository = $projectRepository;
         $this->searchClient = $searchClient;
         $this->searchClientTest = $searchClientTest;
+        $this->curatorenClient = $curatorenClient;
+        $this->curatorenClientTest = $curatorenClientTest;
     }
 
     /**
@@ -101,9 +114,11 @@ class Renderer implements RendererInterface
         if ($project->getStatus() !== ProjectInterface::PROJECT_STATUS_ACTIVE) {
             $apiKey = $project->getTestApiKeySapi3();
             $config = $this->searchClientTest->getClient()->getConfig();
+            $curatorenConfig =  $this->curatorenClientTest->getClient()->getConfig();
         } else {
             $config = $this->searchClient->getClient()->getConfig();
             $apiKey = $project->getLiveApiKeySapi3();
+            $curatorenConfig =  $this->curatorenClient->getClient()->getConfig();
         }
 
         $headers = $config['headers'] ?? [];
@@ -111,6 +126,7 @@ class Renderer implements RendererInterface
         $config['headers'] = $headers;
 
         $this->searchClient->setClient(new \GuzzleHttp\Client($config));
+        $this->curatorenClient->setClient(new \GuzzleHttp\Client($curatorenConfig));
     }
 
     /**

--- a/test/ArticleLinker/CommandHandler/CreateArticleLinkCommandHandlerTest.php
+++ b/test/ArticleLinker/CommandHandler/CreateArticleLinkCommandHandlerTest.php
@@ -39,9 +39,10 @@ class CreateArticleLinkCommandHandlerTest extends \PHPUnit_Framework_TestCase
      * Test the handling of a create article link.
      */
     public function testHandleCreateArticleLink()
-    {
-        $createArticleLink = new CreateArticleLink('my-url', 'my-cdbid');
-        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid');
+    {   
+        $projectActive = false;
+        $createArticleLink = new CreateArticleLink('my-url', 'my-cdbid', $projectActive);
+        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid', $projectActive);
 
         $this->eventBus->expects($this->once())
             ->method('handle')

--- a/test/ArticleLinker/CommandHandler/CreateArticleLinkCommandHandlerTest.php
+++ b/test/ArticleLinker/CommandHandler/CreateArticleLinkCommandHandlerTest.php
@@ -39,7 +39,7 @@ class CreateArticleLinkCommandHandlerTest extends \PHPUnit_Framework_TestCase
      * Test the handling of a create article link.
      */
     public function testHandleCreateArticleLink()
-    {   
+    {
         $projectActive = false;
         $createArticleLink = new CreateArticleLink('my-url', 'my-cdbid', $projectActive);
         $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid', $projectActive);

--- a/test/ArticleLinker/Event/ArticleLinkCreatedTest.php
+++ b/test/ArticleLinker/Event/ArticleLinkCreatedTest.php
@@ -8,8 +8,9 @@ class ArticleLinkCreatedTest extends \PHPUnit_Framework_TestCase
      * Test the getters and setters.
      */
     public function testGetAndSet()
-    {
-        $articleLinkCreated = new ArticleLinkCreated('the-url', 'the-cdbid');
+    {   
+        $projectActive = false;
+        $articleLinkCreated = new ArticleLinkCreated('the-url', 'the-cdbid', $projectActive);
         $this->assertEquals('the-url', $articleLinkCreated->getUrl());
         $this->assertEquals('the-cdbid', $articleLinkCreated->getCdbid());
 

--- a/test/ArticleLinker/Event/ArticleLinkCreatedTest.php
+++ b/test/ArticleLinker/Event/ArticleLinkCreatedTest.php
@@ -8,7 +8,7 @@ class ArticleLinkCreatedTest extends \PHPUnit_Framework_TestCase
      * Test the getters and setters.
      */
     public function testGetAndSet()
-    {   
+    {
         $projectActive = false;
         $articleLinkCreated = new ArticleLinkCreated('the-url', 'the-cdbid', $projectActive);
         $this->assertEquals('the-url', $articleLinkCreated->getUrl());

--- a/test/ArticleLinker/EventListener/ArticleLinkCreatedEventListenerTest.php
+++ b/test/ArticleLinker/EventListener/ArticleLinkCreatedEventListenerTest.php
@@ -19,6 +19,9 @@ class ArticleLinkCreatedEventListenerTest extends \PHPUnit_Framework_TestCase
         $articleLinkerClient = $this
             ->getMockBuilder(ArticleLinkerClientInterface::class)
             ->getMock();
+        $articleLinkerClientTest = $this
+            ->getMockBuilder(ArticleLinkerClientInterface::class)
+            ->getMock();
         $cacheBackend = $this
             ->getMockBuilder(DoctrineCache::class)
             ->disableOriginalConstructor()
@@ -26,6 +29,7 @@ class ArticleLinkCreatedEventListenerTest extends \PHPUnit_Framework_TestCase
 
         $eventListener = new ArticleLinkCreatedEventListener(
             $articleLinkerClient,
+            $articleLinkerClientTest,
             $cacheBackend
         );
 
@@ -33,7 +37,7 @@ class ArticleLinkCreatedEventListenerTest extends \PHPUnit_Framework_TestCase
             ->method('has')
             ->willReturn(true);
 
-        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid');
+        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid', false);
         $eventListener->handle($articleLinkCreated);
     }
 
@@ -45,6 +49,9 @@ class ArticleLinkCreatedEventListenerTest extends \PHPUnit_Framework_TestCase
         $articleLinkerClient = $this
             ->getMockBuilder(ArticleLinkerClientInterface::class)
             ->getMock();
+        $articleLinkerClientTest = $this
+            ->getMockBuilder(ArticleLinkerClientInterface::class)
+            ->getMock();
         $cacheBackend = $this
             ->getMockBuilder(DoctrineCache::class)
             ->disableOriginalConstructor()
@@ -52,6 +59,7 @@ class ArticleLinkCreatedEventListenerTest extends \PHPUnit_Framework_TestCase
 
         $eventListener = new ArticleLinkCreatedEventListener(
             $articleLinkerClient,
+            $articleLinkerClientTest,
             $cacheBackend
         );
 
@@ -63,7 +71,7 @@ class ArticleLinkCreatedEventListenerTest extends \PHPUnit_Framework_TestCase
             ->method('linkArticle')
             ->with('my-url', 'my-cdbid');
 
-        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid');
+        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid', true);
         $eventListener->handle($articleLinkCreated);
     }
 
@@ -75,16 +83,21 @@ class ArticleLinkCreatedEventListenerTest extends \PHPUnit_Framework_TestCase
         $articleLinkerClient = $this
             ->getMockBuilder(ArticleLinkerClientInterface::class)
             ->getMock();
+        
+        $articleLinkerClientTest = $this
+          ->getMockBuilder(ArticleLinkerClientInterface::class)
+          ->getMock();
 
         $eventListener = new ArticleLinkCreatedEventListener(
-            $articleLinkerClient
+            $articleLinkerClient,
+            $articleLinkerClientTest
         );
 
-        $articleLinkerClient->expects($this->once())
+        $articleLinkerClientTest->expects($this->once())
             ->method('linkArticle')
             ->with('my-url', 'my-cdbid');
 
-        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid');
+        $articleLinkCreated = new ArticleLinkCreated('my-url', 'my-cdbid', false);
         $eventListener->handle($articleLinkCreated);
     }
 }


### PR DESCRIPTION
### Added
- new method to get the projectActive status (boolean)
- use the `articlelinker_api_test` url when a project is **not active**
- use the `articlelinker_api` url when a project is **active**
- use the `curatoren_api_test` url when a project  is **not active**
- use the `curatoren_api` url when a project  is **active**

### Fixed
- fixed test api url for articlelinker and curator-api in config.dist.yml

---
Ticket: [https://jira.uitdatabank.be/browse/PROJ-121](https://jira.uitdatabank.be/browse/PROJ-121)