### PR TITLE
use mainLanguage property if preferred and fallback language are not …

### DIFF
--- a/src/Widget/Translation/Service/FilterForKeyWithFallback.php
+++ b/src/Widget/Translation/Service/FilterForKeyWithFallback.php
@@ -14,15 +14,16 @@ class FilterForKeyWithFallback
         $this->fallBackLanguage = $fallBackLanguage;
     }
 
-    public function __invoke(array $values, $preferredLanguage)
+    public function __invoke(array $values, $preferredLanguage, $mainLanguage = 'nl')
     {
         if (empty($values)) {
             return [];
         }
 
         if (!$this->hasPreferred($values, $preferredLanguage)) {
-            return $values[$this->fallBackLanguage];
+            return isset($values[$this->fallBackLanguage]) ? $values[$this->fallBackLanguage] : $values[$mainLanguage];
         }
+
         return $values[$preferredLanguage];
     }
 

--- a/src/Widget/Twig/TwigPreprocessor.php
+++ b/src/Widget/Twig/TwigPreprocessor.php
@@ -140,8 +140,8 @@ class TwigPreprocessor
     {
         $variables = [
             'id' => $event->getCdbid(),
-            'name' => $this->translateStringWithFallback($event->getName(), $langcode),
-            'description' => $this->translateStringWithFallback($event->getDescription(), $langcode),
+            'name' => $this->translateStringWithFallback($event->getName(), $langcode, $event->getMainLanguage()),
+            'description' => $this->translateStringWithFallback($event->getDescription(), $langcode, $event->getMainLanguage()),
             'where' => $event->getLocation() ? $this->preprocessPlace($event->getLocation(), $langcode) : null,
             'when_summary' => $this->formatEventDatesSummary($event, $langcode),
             'expired' => ($event->getEndDate() ? $event->getEndDate()->format('Y-m-d H:i:s') < date('Y-m-d H:i:s') : false),
@@ -410,7 +410,7 @@ class TwigPreprocessor
             foreach ($priceInfos as $priceInfo) {
                 /** @var TranslatedString $priceName */
                 $priceName = $priceInfo->getName();
-                $translatedPriceName = $this->translateStringWithFallback($priceName, $preferredLanguage);
+                $translatedPriceName = $this->translateStringWithFallback($priceName, $preferredLanguage, $event->getMainLanguage());
                 $priceAmount = $priceInfo->getPrice() > 0 ? '&euro; ' . (float) $priceInfo->getPrice() : $this->translator->trans('event_price_free', [], 'messages', $preferredLanguage);
                 if ($priceInfo->getCategory() !== 'base') {
                     $prices[] = $translatedPriceName . ': ' . $priceAmount;
@@ -477,7 +477,7 @@ class TwigPreprocessor
             if ($bookingInfo->getUrl()) {
                 $variables['booking_info']['url'] = [
                    'url' => $bookingInfo->getUrl(),
-                   'label' => ($this->translateStringWithFallback($bookingInfo->getUrlLabel(), $langcode) !== '') ? $this->translateStringWithFallback($bookingInfo->getUrlLabel(), $langcode) : $bookingInfo->getUrl(),
+                   'label' => ($this->translateStringWithFallback($bookingInfo->getUrlLabel(), $langcode) !== '') ? $this->translateStringWithFallback($bookingInfo->getUrlLabel(), $langcode, $event->getMainLanguage()) : $bookingInfo->getUrl(),
                 ];
             }
         }
@@ -587,14 +587,13 @@ class TwigPreprocessor
      */
     public function preprocessPlace(Place $place, $langcode)
     {
-
         $variables = [];
-        $variables['name'] = $this->translateStringWithFallback($place->getName(), $langcode);
+        $variables['name'] = $this->translateStringWithFallback($place->getName(), $langcode, $place->getMainLanguage());
         $variables['address'] = [];
 
         if ($address = $place->getAddress()) {
             /** @var TranslatedAddress $address */
-            $translatedAddress = $this->translateAddress($address, $langcode);
+            $translatedAddress = $this->translateAddress($address, $langcode, $place->getMainLanguage());
                 $variables['address']['street'] = $translatedAddress->getStreetAddress() ?? '';
                 $variables['address']['postalcode'] = $translatedAddress->getPostalCode() ?? '';
                 $variables['address']['city'] = $translatedAddress->getAddressLocality() ?? '';
@@ -820,17 +819,17 @@ class TwigPreprocessor
         }
     }
 
-    protected function translateStringWithFallback(?TranslatedString $translatedString, $preferredLanguage)
+    protected function translateStringWithFallback(?TranslatedString $translatedString, $preferredLanguage, $mainLanguage = 'nl')
     {
         if ($translatedString === null) {
             return '';
         }
-        return $this->filterForKeyWithFallback->__invoke($translatedString->getValues(), $preferredLanguage);
+        return $this->filterForKeyWithFallback->__invoke($translatedString->getValues(), $preferredLanguage, $mainLanguage);
     }
 
-    protected function translateAddress(TranslatedAddress $translatedAddress, string $prefferedLanguage)
+    protected function translateAddress(TranslatedAddress $translatedAddress, string $prefferedLanguage, $mainLanguage = 'nl')
     {
-        $invoke = $this->filterForKeyWithFallback->__invoke($translatedAddress->getAddresses(), $prefferedLanguage);
+        $invoke = $this->filterForKeyWithFallback->__invoke($translatedAddress->getAddresses(), $prefferedLanguage, $mainLanguage);
         return $invoke;
     }
 

--- a/test/Widget/Translation/Service/FilterForKeyWithFallbackTest.php
+++ b/test/Widget/Translation/Service/FilterForKeyWithFallbackTest.php
@@ -53,6 +53,19 @@ class FilterForKeyWithFallbackTest extends TestCase
     /**
      * @test
      */
+    public function it_returns_main_language_array_if_preferred_and_fallback_is_not_present()
+    {
+        $values = [
+          'fr' => 'main-language-translation',
+        ];
+
+        $result = $this->translateLanguage->__invoke($values, self::PREFERRED_KEY, 'fr');
+        $this->assertEquals('main-language-translation', $result);
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_empty_array_if_no_values()
     {
         $result = $this->translateLanguage->__invoke([], self::PREFERRED_KEY);


### PR DESCRIPTION
### Added
In some cases there is no translation available for fallback or preferredLanguage.
In this case we need to check which language is available in the json of the event.
I used the `mainLanguage` as a fallback for these edge cases.

E.g. with following event data
![event-with-fr-info](https://user-images.githubusercontent.com/9402377/72736695-7ad6f200-3b9e-11ea-82de-57ceaaa5ec85.png)

The widget is rendered  in `en` so the widget will try to the translate the `location.name` into english however the key doesn't exist on this data so he will use the fallbacklanguage `nl` to translate but this doesn't exist either. 

So now we use the `mainLanguage` as a second fallback.
