### PR TITLE
Bugfix/wid 307

### DIFF
--- a/src/Widget/Translation/Service/FilterForKeyWithFallback.php
+++ b/src/Widget/Translation/Service/FilterForKeyWithFallback.php
@@ -31,7 +31,6 @@ class FilterForKeyWithFallback
 
             $firstKey = array_keys($values)[0];
             return $values[$firstKey];
-
         }
 
         return $values[$preferredLanguage];
@@ -46,5 +45,4 @@ class FilterForKeyWithFallback
     {
         return isset($values[$mainLanguage]);
     }
-
 }

--- a/src/Widget/Translation/Service/FilterForKeyWithFallback.php
+++ b/src/Widget/Translation/Service/FilterForKeyWithFallback.php
@@ -21,7 +21,14 @@ class FilterForKeyWithFallback
         }
 
         if (!$this->hasPreferred($values, $preferredLanguage)) {
-            return isset($values[$this->fallBackLanguage]) ? $values[$this->fallBackLanguage] : $values[$mainLanguage];
+            if (isset($values[$this->fallBackLanguage])) {
+              return $values[$this->fallBackLanguage];
+            } elseif (isset($values[$mainLanguage])) {
+              return $values[$mainLanguage];
+            } else {
+              $firstKey = array_keys($values)[0];
+              return $values[$firstKey];
+            }
         }
 
         return $values[$preferredLanguage];

--- a/src/Widget/Translation/Service/FilterForKeyWithFallback.php
+++ b/src/Widget/Translation/Service/FilterForKeyWithFallback.php
@@ -22,12 +22,12 @@ class FilterForKeyWithFallback
 
         if (!$this->hasPreferred($values, $preferredLanguage)) {
             if (isset($values[$this->fallBackLanguage])) {
-              return $values[$this->fallBackLanguage];
+                return $values[$this->fallBackLanguage];
             } elseif (isset($values[$mainLanguage])) {
-              return $values[$mainLanguage];
+                return $values[$mainLanguage];
             } else {
-              $firstKey = array_keys($values)[0];
-              return $values[$firstKey];
+                $firstKey = array_keys($values)[0];
+                return $values[$firstKey];
             }
         }
 

--- a/src/Widget/Translation/Service/FilterForKeyWithFallback.php
+++ b/src/Widget/Translation/Service/FilterForKeyWithFallback.php
@@ -23,12 +23,15 @@ class FilterForKeyWithFallback
         if (!$this->hasPreferred($values, $preferredLanguage)) {
             if (isset($values[$this->fallBackLanguage])) {
                 return $values[$this->fallBackLanguage];
-            } elseif (isset($values[$mainLanguage])) {
-                return $values[$mainLanguage];
-            } else {
-                $firstKey = array_keys($values)[0];
-                return $values[$firstKey];
             }
+
+            if ($this->hasMainLanguage($values, $mainLanguage)) {
+                return $values[$mainLanguage];
+            }
+
+            $firstKey = array_keys($values)[0];
+            return $values[$firstKey];
+
         }
 
         return $values[$preferredLanguage];
@@ -38,4 +41,10 @@ class FilterForKeyWithFallback
     {
         return isset($values[$preferredLanguage]);
     }
+
+    protected function hasMainLanguage(array $values, $mainLanguage): bool
+    {
+        return isset($values[$mainLanguage]);
+    }
+
 }

--- a/src/Widget/Twig/TwigPreprocessor.php
+++ b/src/Widget/Twig/TwigPreprocessor.php
@@ -155,7 +155,7 @@ class TwigPreprocessor
             'uitpas' => $this->isUitpasEvent($event),
             'museumpas' => $this->isMuseumpasEvent($event),
             'facilities' => $this->getFacilitiesWithPresentInformation($event),
-            'typeId' => ($event->getTermsByDomain('eventtype')[0]->getId()) ?: null,
+            'typeId' => (count($event->getTermsByDomain('eventtype')) > 0) ? $event->getTermsByDomain('eventtype')[0]->getId() : null,
         ];
         $defaultImage = $settings['image']['default_image'] ? $this->request->getScheme() . '://media.uitdatabank.be/static/uit-placeholder.png' : '';
         $image = $event->getImage() ?? $defaultImage;

--- a/test/Widget/Translation/Service/FilterForKeyWithFallbackTest.php
+++ b/test/Widget/Translation/Service/FilterForKeyWithFallbackTest.php
@@ -63,6 +63,18 @@ class FilterForKeyWithFallbackTest extends TestCase
         $this->assertEquals('main-language-translation', $result);
     }
 
+        /**
+     * @test
+     */
+    public function it_returns_first_available_language_if_preferred_and_fallback_and_main_language_are_not_present()
+    {
+        $values = [
+          'en' => 'english event',
+        ];
+        $result = $this->translateLanguage->__invoke($values, self::PREFERRED_KEY, 'fr');
+        $this->assertEquals('english event', $result);
+    }
+
     /**
      * @test
      */
@@ -71,4 +83,5 @@ class FilterForKeyWithFallbackTest extends TestCase
         $result = $this->translateLanguage->__invoke([], self::PREFERRED_KEY);
         $this->assertEquals([], $result);
     }
+
 }

--- a/test/Widget/Translation/Service/FilterForKeyWithFallbackTest.php
+++ b/test/Widget/Translation/Service/FilterForKeyWithFallbackTest.php
@@ -83,5 +83,4 @@ class FilterForKeyWithFallbackTest extends TestCase
         $result = $this->translateLanguage->__invoke([], self::PREFERRED_KEY);
         $this->assertEquals([], $result);
     }
-
 }


### PR DESCRIPTION
### Fixed
- Fixed issue for translation for when example the preferredLanguage is `nl` and the event's main language is `nl` but the event only has an `fr`key.
- Fixed issue with labels -> only get id of terms if it actually has terms. 

---
Ticket: [https://jira.uitdatabank.be/browse/WID-307](https://jira.uitdatabank.be/browse/WID-307)