### PR TITLE
WID-329 - fix wrong name for waasland region

### DIFF
--- a/locales/region/en.yml
+++ b/locales/region/en.yml
@@ -1069,7 +1069,7 @@ nis-45017D: Nokere (Kruisem)
 nis-45057C: Huise (Kruisem)
 nis-45057B: Ouwegem (Kruisem)
 nis-45057A: Zingem (Kruisem)
-reg-waasland: Voeren (region)
+reg-waasland: Waasland (region)
 nis-11056: Zwijndrecht + submunicipalities
 nis-11056B: Burcht (Zwijndrecht)
 nis-11056A: Zwijndrecht (Zwijndrecht)

--- a/locales/region/fr.yml
+++ b/locales/region/fr.yml
@@ -1069,7 +1069,7 @@ nis-45017D: Nokere (Kruisem)
 nis-45057C: Huise (Kruisem)
 nis-45057B: Ouwegem (Kruisem)
 nis-45057A: Zingem (Kruisem)
-reg-waasland: Région de Fourons
+reg-waasland: Le pays de Waes
 nis-11056: Zwijndrecht + sous-municipalités
 nis-11056B: Burcht (Zwijndrecht)
 nis-11056A: Zwijndrecht (Zwijndrecht)


### PR DESCRIPTION
### Fixed
- fix wrong name for waasland region

---
Ticket: [https://jira.uitdatabank.be/browse/WID-329](https://jira.uitdatabank.be/browse/WID-329)