### PR TITLE
Feature/wid 313

### DIFF
--- a/src/Widget/Twig/TwigPreprocessor.php
+++ b/src/Widget/Twig/TwigPreprocessor.php
@@ -120,9 +120,7 @@ class TwigPreprocessor
             $preprocessedEvent = $this->preprocessEvent($event, $preferredLanguage, $settings['items']);
 
             $linkType = 'query';
-            $requestUrl = parse_url($this->request->server->get('REQUEST_URI'));
-            parse_str($requestUrl['query'], $requestQuery);
-            $detailUrl = $requestQuery['origin'];
+            $detailUrl = $this->request->query->get('origin', '');
             if (isset($settings['general']['detail_link'])) {
                 $detailUrl = $settings['general']['detail_link']['url'] ?? $detailUrl;
                 $linkType = $settings['general']['detail_link']['cdbid'] ?? $linkType;

--- a/src/Widget/Twig/TwigPreprocessor.php
+++ b/src/Widget/Twig/TwigPreprocessor.php
@@ -120,10 +120,9 @@ class TwigPreprocessor
             $preprocessedEvent = $this->preprocessEvent($event, $preferredLanguage, $settings['items']);
 
             $linkType = 'query';
-            $detailUrl = $this->request->server->get('HTTP_REFERER');
-            $requestUrl = parse_url($this->request->server->get('REQUEST_URI'))->getQuery();
-            $origin = $requestUrl['origin'];
-            var_dump('origin ' . $origin);
+            $requestUrl = parse_url($this->request->server->get('REQUEST_URI'));
+            parse_str($requestUrl['query'], $requestQuery);
+            $detailUrl = $requestQuery['origin'];
             if (isset($settings['general']['detail_link'])) {
                 $detailUrl = $settings['general']['detail_link']['url'] ?? $detailUrl;
                 $linkType = $settings['general']['detail_link']['cdbid'] ?? $linkType;

--- a/src/Widget/Twig/TwigPreprocessor.php
+++ b/src/Widget/Twig/TwigPreprocessor.php
@@ -121,6 +121,9 @@ class TwigPreprocessor
 
             $linkType = 'query';
             $detailUrl = $this->request->server->get('HTTP_REFERER');
+            $requestUrl = parse_url($this->request->server->get('REQUEST_URI'))->getQuery();
+            $origin = $requestUrl['origin'];
+            var_dump('origin ' . $origin);
             if (isset($settings['general']['detail_link'])) {
                 $detailUrl = $settings['general']['detail_link']['url'] ?? $detailUrl;
                 $linkType = $settings['general']['detail_link']['cdbid'] ?? $linkType;

--- a/web/assets/js/widgets/core/widgets.js
+++ b/web/assets/js/widgets/core/widgets.js
@@ -194,12 +194,14 @@ window.CultuurnetWidgets = window.CultuurnetWidgets || { behaviors: {} };
      * Render a given widget.
      */
     CultuurnetWidgets.renderWidget = function(widgetId, widgetPageId) {
-
         var deferred = jQuery.Deferred();
+
+        var origin = window.location.href;
+        console.log(origin);
 
         // Only render the widget if it's a known id.
         if (CultuurnetWidgetsSettings[widgetPageId].widgetMapping && CultuurnetWidgetsSettings[widgetPageId].widgetMapping.hasOwnProperty(widgetId)) {
-            return CultuurnetWidgets.apiRequest(CultuurnetWidgetsSettings[widgetPageId].apiUrl + '/render/' + CultuurnetWidgetsSettings[widgetPageId].widgetMapping[widgetId] + '/' + widgetId);
+            return CultuurnetWidgets.apiRequest(CultuurnetWidgetsSettings[widgetPageId].apiUrl + '/render/' + CultuurnetWidgetsSettings[widgetPageId].widgetMapping[widgetId] + '/' + widgetId + '?origin=' + origin);
         }
         else {
             deferred.reject('The given widget id was not found');
@@ -232,9 +234,12 @@ window.CultuurnetWidgets = window.CultuurnetWidgets || { behaviors: {} };
 
         var deferred = jQuery.Deferred();
 
+        var origin = window.location.href;
+        console.log(origin);
+
         // Only render the widget if it's a known id.
         if (CultuurnetWidgetsSettings[widgetPageId].widgetMapping && CultuurnetWidgetsSettings[widgetPageId].widgetMapping.hasOwnProperty(widgetId)) {
-            return CultuurnetWidgets.apiRequest(CultuurnetWidgetsSettings[widgetPageId].apiUrl + '/render/' + CultuurnetWidgetsSettings[widgetPageId].widgetMapping[widgetId] + '/' + widgetId + '/search-results-with-facets');
+            return CultuurnetWidgets.apiRequest(CultuurnetWidgetsSettings[widgetPageId].apiUrl + '/render/' + CultuurnetWidgetsSettings[widgetPageId].widgetMapping[widgetId] + '/' + widgetId + '/search-results-with-facets' + '?origin=' + origin );
         }
         else {
             deferred.reject('The given widget id was not found');

--- a/web/assets/js/widgets/core/widgets.js
+++ b/web/assets/js/widgets/core/widgets.js
@@ -195,9 +195,7 @@ window.CultuurnetWidgets = window.CultuurnetWidgets || { behaviors: {} };
      */
     CultuurnetWidgets.renderWidget = function(widgetId, widgetPageId) {
         var deferred = jQuery.Deferred();
-
         var origin = window.location.href;
-        console.log(origin);
 
         // Only render the widget if it's a known id.
         if (CultuurnetWidgetsSettings[widgetPageId].widgetMapping && CultuurnetWidgetsSettings[widgetPageId].widgetMapping.hasOwnProperty(widgetId)) {
@@ -233,9 +231,7 @@ window.CultuurnetWidgets = window.CultuurnetWidgets || { behaviors: {} };
     CultuurnetWidgets.renderSearchResults = function(widgetId, widgetPageId) {
 
         var deferred = jQuery.Deferred();
-
         var origin = window.location.href;
-        console.log(origin);
 
         // Only render the widget if it's a known id.
         if (CultuurnetWidgetsSettings[widgetPageId].widgetMapping && CultuurnetWidgetsSettings[widgetPageId].widgetMapping.hasOwnProperty(widgetId)) {


### PR DESCRIPTION
### Changed
- pass the origin `window.location.href` to the render method so it can be used for building the detail page url instead of using the `HTTP_REFERER` since it's not reliable.

---
Ticket: [https://jira.uitdatabank.be/browse/WID-313](https://jira.uitdatabank.be/browse/WID-313)