### PR TITLE
Feature/proj 140

### DIFF
--- a/app/Project/ProjectProvider.php
+++ b/app/Project/ProjectProvider.php
@@ -30,16 +30,8 @@ class ProjectProvider implements ServiceProviderInterface
             return new ProjectConverter($pimple['project_repository']);
         };
 
-        $pimple['default_consumer_group'] = function (Container $pimple) {
-            return $pimple['config']['default_consumer_group'];
-        };
-
-        $pimple['uitpas_permission_group'] = function (Container $pimple) {
-            return $pimple['config']['uitpas_permission_group'];
-        };
-
-        $pimple['auth0_refresh_token_permission_group'] = function (Container $pimple) {
-            return $pimple['config']['auth0_refresh_token_permission_group'];
+        $pimple['permission_groups'] = function (Container $pimple) {
+            return $pimple['config']['permission_groups'];
         };
     }
 }

--- a/app/Project/ProjectProvider.php
+++ b/app/Project/ProjectProvider.php
@@ -37,5 +37,9 @@ class ProjectProvider implements ServiceProviderInterface
         $pimple['uitpas_permission_group'] = function (Container $pimple) {
             return $pimple['config']['uitpas_permission_group'];
         };
+
+        $pimple['auth0_refresh_token_permission_group'] = function (Container $pimple) {
+            return $pimple['config']['auth0_refresh_token_permission_group'];
+        };
     }
 }

--- a/app/config/messagebus.yml
+++ b/app/config/messagebus.yml
@@ -96,9 +96,7 @@ handlers:
             - culturefeed_test
             - culturefeed
             - uitid_user_session_data_complete
-            - default_consumer_group
-            - uitpas_permission_group
-            - auth0_refresh_token_permission_group
+            - permission_groups
 
     activate_project_handler:
         command: CultuurNet\ProjectAanvraag\Project\Command\ActivateProject
@@ -108,9 +106,7 @@ handlers:
             - orm.em
             - culturefeed
             - uitid_user_session_data_complete
-            - default_consumer_group
-            - uitpas_permission_group
-            - auth0_refresh_token_permission_group
+            - permission_groups
 
     request_activation_handler:
         command: CultuurNet\ProjectAanvraag\Project\Command\RequestActivation

--- a/app/config/messagebus.yml
+++ b/app/config/messagebus.yml
@@ -98,6 +98,7 @@ handlers:
             - uitid_user_session_data_complete
             - default_consumer_group
             - uitpas_permission_group
+            - auth0_refresh_token_permission_group
 
     activate_project_handler:
         command: CultuurNet\ProjectAanvraag\Project\Command\ActivateProject
@@ -109,6 +110,7 @@ handlers:
             - uitid_user_session_data_complete
             - default_consumer_group
             - uitpas_permission_group
+            - auth0_refresh_token_permission_group
 
     request_activation_handler:
         command: CultuurNet\ProjectAanvraag\Project\Command\RequestActivation

--- a/app/config/messagebus.yml
+++ b/app/config/messagebus.yml
@@ -96,7 +96,7 @@ handlers:
             - culturefeed_test
             - culturefeed
             - uitid_user_session_data_complete
-            - permission_groups
+            - integration_types.storage
 
     activate_project_handler:
         command: CultuurNet\ProjectAanvraag\Project\Command\ActivateProject
@@ -106,7 +106,7 @@ handlers:
             - orm.em
             - culturefeed
             - uitid_user_session_data_complete
-            - permission_groups
+            - integration_types.storage
 
     request_activation_handler:
         command: CultuurNet\ProjectAanvraag\Project\Command\RequestActivation

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -132,11 +132,19 @@ css_stats:
 # Google tag manager code
 google_tag_manager:
 
-permission_groups: 
-  24378: [3, 24378] # widgets
-  24379: [3, 24379] # api 3
-  24380: [3, 24380, 24640] # entry_v3
-  22678: [22678] # uitpas
+permission_groups:
+  # Widgets
+  24378:
+    uitid: [3, 24378]
+    uitpas: 22678
+  # API 3
+  24379:
+    uitid: [3, 24379]
+    uitpas: 22678
+  # EntryAPI3
+  24380:
+    uitid: [3, 24380, 24640]
+    uitpas: 22678
 
 # App-URL
 app_host: "http://projectaanvraag.uitdatabank.be"

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -132,14 +132,11 @@ css_stats:
 # Google tag manager code
 google_tag_manager:
 
-# The default consumer group to use
-default_consumer_group: 3
-
-# The uitpas permission group
-uitpas_permission_group: 22678
-
-# auth0 refresh token permission group
-auth0_refresh_token_permission_group: 
+permission_groups: 
+  default_consumer: 3
+  auth0_refresh_token: 24640
+  entry_v3: 24380
+  uitpas: 22678
 
 # App-URL
 app_host: "http://projectaanvraag.uitdatabank.be"

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -132,20 +132,6 @@ css_stats:
 # Google tag manager code
 google_tag_manager:
 
-permission_groups:
-  # Widgets
-  24378:
-    uitid: [3, 24378]
-    uitpas: 22678
-  # API 3
-  24379:
-    uitid: [3, 24379]
-    uitpas: 22678
-  # EntryAPI3
-  24380:
-    uitid: [3, 24380, 24640]
-    uitpas: 22678
-
 # App-URL
 app_host: "http://projectaanvraag.uitdatabank.be"
 social_host: "http://social.uit.be"

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -138,6 +138,9 @@ default_consumer_group: 3
 # The uitpas permission group
 uitpas_permission_group: 22678
 
+# auth0 refresh token permission group
+auth0_refresh_token_permission_group: 
+
 # App-URL
 app_host: "http://projectaanvraag.uitdatabank.be"
 social_host: "http://social.uit.be"

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -133,10 +133,10 @@ css_stats:
 google_tag_manager:
 
 permission_groups: 
-  default_consumer: 3
-  auth0_refresh_token: 24640
-  entry_v3: 24380
-  uitpas: 22678
+  24378: [3, 24378] # widgets
+  24379: [3, 24379] # api 3
+  24380: [3, 24380, 24640] # entry_v3
+  22678: [22678] # uitpas
 
 # App-URL
 app_host: "http://projectaanvraag.uitdatabank.be"

--- a/integration_types.dist.yml
+++ b/integration_types.dist.yml
@@ -15,6 +15,8 @@ integration_types:
       type: 'output'
       self_service: true
       enable_activation: true
+      uitid_permissions: [3, 24378]
+      uitpas_permissions: [22678]
   24379:
       name: 'API3'
       description: 'Toegang tot de nieuwste zoekengine van de UiTdatabank'
@@ -29,6 +31,8 @@ integration_types:
       type: 'output'
       self_service: true
       enable_activation: true
+      uitid_permissions: [3, 24379]
+      uitpas_permissions: [22678]
   24380:
       name: 'Entry API'
       description: 'Via Entry API kan je items in UiTdatabank aanmaken, aanpassen en verwijderen.'
@@ -43,6 +47,8 @@ integration_types:
       self_service: false
       type: 'input'
       enable_activation: true
+      uitid_permissions: [3, 24380, 24640]
+      uitpas_permissions: [22678]
   24745:
       name: 'Culturefeed'
       description: 'Modules waarmee je een UiTagenda integreert in een Drupal-site'

--- a/integration_types.dist.yml
+++ b/integration_types.dist.yml
@@ -1,30 +1,73 @@
 # Integration types
 integration_types:
-  22678:
+  24378:
       name: 'Widgets' # name of the type
       description: 'Kant en klare html-modules die je in je website kan inpassen' # description show on the form
       price: 110.0 # price for this widget
       url: '/#!/integrations#widgets' # url for more information
+      get_started_url: 'http://documentatie.uitdatabank.be/content/widgets/latest/index.html'
       extra_info: # list of bullet points that are shown in the footer of the application
         - 'Geschikt voor basisoplossingen'
-        - 'Zelf of door CultuurNet in te stellen'
+        - 'Zelf of door publiq in te stellen'
       action_button: 'widgets'
       group_id: 'group_id'
-  22679:
+      sapi_version: 3
+      type: 'output'
+      self_service: true
+      enable_activation: true
+  24379:
+      name: 'API3'
+      description: 'Toegang tot de nieuwste zoekengine van de UiTdatabank'
+      price: 80.0
+      url: '/#!/integrations#api'
+      get_started_url: 'https://documentatie.uitdatabank.be/content/search_api_3/latest/getting-started.html'
+      extra_info:
+        - 'Gestoeld op de JSON-LD-technologie'
+        - 'Robuuste performantie'
+      group_id: 'group_id'
+      sapi_version: 3
+      type: 'output'
+      self_service: true
+      enable_activation: true
+  24380:
+      name: 'Entry API'
+      description: 'Via Entry API kan je items in UiTdatabank aanmaken, aanpassen en verwijderen.'
+      price: 0
+      url: '/#!/integrations#api'
+      get_started_url: 'https://documentatie.uitdatabank.be/content/entry_api_3/latest/start.html'
+      extra_info:
+        - 'JSON-standaard'
+        - 'Activatie op live-omgeving enkel op aanvraag'
+      group_id: 'group_id'
+      sapi_version: 3
+      self_service: false
+      type: 'input'
+      enable_activation: true
+  24745:
       name: 'Culturefeed'
       description: 'Modules waarmee je een UiTagenda integreert in een Drupal-site'
       price: 80.0
       url: '/#!/integrations#culturefeed'
+      get_started_url: 'https://github.com/cultuurnet/culturefeed/wiki'
       extra_info:
         - 'Van agenda tot een volledige (campagne)website'
         - 'Fijngestelde SEO'
       group_id: 'group_id'
-  22677:
-      name: 'API'
-      description: 'Met deze API krijg je toegang tot de zoekengine van de UiTdatabank'
+      sapi_version: 2
+      type: 'output'
+      self_service: true
+      enable_activation: false
+  24742:
+      name: 'API2'
+      description: 'Toegang tot de zoekengine van de UiTdatabank'
       price: 80.0
       url: '/#!/integrations#api'
+      get_started_url: 'http://documentatie.uitdatabank.be/content/search_api/latest/start.html'
       extra_info:
-        - 'Platformonafhankelijk'
-        - 'Individuele oplossingen op maat mogelijk'
+        - 'Platformonafhankelijk via XML-standaard'
+        - 'Individuele oplossingen op maat zijn mogelijk'
       group_id: 'group_id'
+      sapi_version: 2
+      type: 'output'
+      self_service: true
+      enable_activation: false

--- a/src/IntegrationType/IntegrationType.php
+++ b/src/IntegrationType/IntegrationType.php
@@ -78,6 +78,15 @@ class IntegrationType implements \JsonSerializable
      */
     protected $enableActivation;
 
+    /**
+     * @var array
+     */
+    private $uitIdPermissionGroups;
+
+    /**
+     * @var array
+     */
+    private $uitPasPermissionGroups;
 
     /**
      * @return string
@@ -311,6 +320,26 @@ class IntegrationType implements \JsonSerializable
     {
         $this->type = $type;
         return $this;
+    }
+
+    public function getUitIdPermissionGroups(): array
+    {
+        return $this->uitIdPermissionGroups;
+    }
+
+    public function setUitIdPermissionGroups($uitIdPermissionGroups): void
+    {
+        $this->uitIdPermissionGroups = $uitIdPermissionGroups;
+    }
+
+    public function getUitPasPermissionGroups(): array
+    {
+        return $this->uitPasPermissionGroups;
+    }
+
+    public function setUitPasPermissionGroups($uitPasPermissionGroups): void
+    {
+        $this->uitPasPermissionGroups = $uitPasPermissionGroups;
     }
 
     /**

--- a/src/IntegrationType/IntegrationTypeStorage.php
+++ b/src/IntegrationType/IntegrationTypeStorage.php
@@ -72,6 +72,8 @@ class IntegrationTypeStorage implements IntegrationTypeStorageInterface
                 $integrationType->setSelfService(isset($type['self_service']) ? $type['self_service'] : true);
                 $integrationType->setEnableActivation(isset($type['enable_activation']) ? $type['enable_activation'] : true);
                 $integrationType->setType(!empty($type['type']) ? $type['type'] : 'output');
+                $integrationType->setUitIdPermissionGroups($type['uitid_permissions'] ?? []);
+                $integrationType->setUitPasPermissionGroups($type['uitpas_permissions'] ?? []);
                 $this->integrationTypes[$integrationType->getId()] = $integrationType;
             }
         }

--- a/src/Project/CommandHandler/ActivateProjectCommandHandler.php
+++ b/src/Project/CommandHandler/ActivateProjectCommandHandler.php
@@ -73,7 +73,7 @@ class ActivateProjectCommandHandler
         $createConsumer->group = [$this->permissionGroups['default_consumer'], $project->getGroupId()];
 
         if ($project->getGroupId() === $this->permissionGroups['entry_v3']) {
-          $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
+            $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
         }
 
         if ($project->getSapiVersion() == '3') {

--- a/src/Project/CommandHandler/ActivateProjectCommandHandler.php
+++ b/src/Project/CommandHandler/ActivateProjectCommandHandler.php
@@ -68,10 +68,10 @@ class ActivateProjectCommandHandler
 
         // Create the consumer
         $createConsumer = new \CultureFeed_Consumer();
-        $groupId = $project->getGroupId();
         $createConsumer->name = $project->getName();
         $createConsumer->description = $project->getDescription();
-        $createConsumer->group = $this->permissionGroups[$groupId];
+        $groupId = $project->getGroupId();
+        $createConsumer->group = $this->permissionGroups[$groupId]['uitid'];
 
         if ($project->getSapiVersion() == '3') {
             $createConsumer->searchPrefixSapi3 = $project->getContentFilter();
@@ -87,7 +87,7 @@ class ActivateProjectCommandHandler
         $this->cultureFeedLive->addServiceConsumerAdmin($cultureFeedConsumer->consumerKey, $this->user->id);
 
         // Add uitpas permssion to consumer
-        $this->cultureFeedLive->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups[22678]);
+        $this->cultureFeedLive->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups[$groupId]['uitpas']);
 
         // Update local db.
         $project->setStatus(ProjectInterface::PROJECT_STATUS_ACTIVE);

--- a/src/Project/CommandHandler/ActivateProjectCommandHandler.php
+++ b/src/Project/CommandHandler/ActivateProjectCommandHandler.php
@@ -68,13 +68,10 @@ class ActivateProjectCommandHandler
 
         // Create the consumer
         $createConsumer = new \CultureFeed_Consumer();
+        $groupId = $project->getGroupId();
         $createConsumer->name = $project->getName();
         $createConsumer->description = $project->getDescription();
-        $createConsumer->group = [$this->permissionGroups['default_consumer'], $project->getGroupId()];
-
-        if ($project->getGroupId() === $this->permissionGroups['entry_v3']) {
-            $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
-        }
+        $createConsumer->group = $this->permissionGroups[$groupId];
 
         if ($project->getSapiVersion() == '3') {
             $createConsumer->searchPrefixSapi3 = $project->getContentFilter();
@@ -90,7 +87,7 @@ class ActivateProjectCommandHandler
         $this->cultureFeedLive->addServiceConsumerAdmin($cultureFeedConsumer->consumerKey, $this->user->id);
 
         // Add uitpas permssion to consumer
-        $this->cultureFeedLive->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups['uitpas']);
+        $this->cultureFeedLive->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups[22678]);
 
         // Update local db.
         $project->setStatus(ProjectInterface::PROJECT_STATUS_ACTIVE);

--- a/src/Project/CommandHandler/CreateProjectCommandHandler.php
+++ b/src/Project/CommandHandler/CreateProjectCommandHandler.php
@@ -98,7 +98,7 @@ class CreateProjectCommandHandler
             $createConsumer->description = $createProject->getDescription();
             $createConsumer->group = [$this->permissionGroups['default_consumer'], $createProject->getIntegrationType()];
             if ($createProject->getIntegrationType() === $this->permissionGroups['entry_v3']) {
-              $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
+                $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
             }
             $cultureFeedLiveConsumer = $this->cultureFeed->createServiceConsumer($createConsumer);
             // Add uitpas permission to consumer
@@ -185,7 +185,7 @@ class CreateProjectCommandHandler
         $createConsumer->description = $createProject->getDescription();
         $createConsumer->group = [$this->permissionGroups['default_consumer'], $createProject->getIntegrationType()];
         if ($createProject->getIntegrationType() === $this->permissionGroups['entry_v3']) {
-          $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
+            $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
         }
 
         $cultureFeedConsumer = $this->cultureFeedTest->createServiceConsumer($createConsumer);

--- a/src/Project/CommandHandler/CreateProjectCommandHandler.php
+++ b/src/Project/CommandHandler/CreateProjectCommandHandler.php
@@ -183,10 +183,8 @@ class CreateProjectCommandHandler
         $createConsumer = new \CultureFeed_Consumer();
         $createConsumer->name = $createProject->getName();
         $createConsumer->description = $createProject->getDescription();
-        $createConsumer->group = [$this->permissionGroups['default_consumer'], $createProject->getIntegrationType()];
-        if ($createProject->getIntegrationType() === $this->permissionGroups['entry_v3']) {
-            $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
-        }
+        $integrationType =  $createProject->getIntegrationType();
+        $createConsumer->group = $this->permissionGroups[$integrationType];
 
         $cultureFeedConsumer = $this->cultureFeedTest->createServiceConsumer($createConsumer);
 
@@ -194,7 +192,7 @@ class CreateProjectCommandHandler
         $this->cultureFeedTest->addServiceConsumerAdmin($cultureFeedConsumer->consumerKey, $uid);
 
         // Add uitpas permission to consumer
-        $this->cultureFeedTest->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups['uitpas']);
+        $this->cultureFeedTest->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups[22678]);
 
         return $cultureFeedConsumer;
     }

--- a/src/Project/CommandHandler/CreateProjectCommandHandler.php
+++ b/src/Project/CommandHandler/CreateProjectCommandHandler.php
@@ -5,6 +5,8 @@ namespace CultuurNet\ProjectAanvraag\Project\CommandHandler;
 use CultuurNet\ProjectAanvraag\Entity\Coupon;
 use CultuurNet\ProjectAanvraag\Entity\Project;
 use CultuurNet\ProjectAanvraag\Entity\User;
+use CultuurNet\ProjectAanvraag\IntegrationType\IntegrationType;
+use CultuurNet\ProjectAanvraag\IntegrationType\IntegrationTypeStorageInterface;
 use CultuurNet\ProjectAanvraag\PasswordGeneratorTrait;
 use CultuurNet\ProjectAanvraag\Project\Command\CreateProject;
 use CultuurNet\ProjectAanvraag\Project\Event\ProjectCreated;
@@ -43,27 +45,24 @@ class CreateProjectCommandHandler
     protected $user;
 
     /**
-     * @var array
+     * @var IntegrationTypeStorageInterface
      */
-    protected $permissionGroups;
+    private $integrationTypeStorage;
 
-    /**
-     * CreateProjectCommandHandler constructor.
-     * @param MessageBusSupportingMiddleware $eventBus
-     * @param EntityManagerInterface $entityManager
-     * @param \ICultureFeed $cultureFeedTest
-     * @param \ICultureFeed $cultureFeed
-     * @param UitIdUserInterface $user
-     * @param array $permissionGroups
-     */
-    public function __construct(MessageBusSupportingMiddleware $eventBus, EntityManagerInterface $entityManager, \ICultureFeed $cultureFeedTest, \ICultureFeed $cultureFeed, UitIdUserInterface $user, $permissionGroups)
-    {
+    public function __construct(
+        MessageBusSupportingMiddleware $eventBus,
+        EntityManagerInterface $entityManager,
+        \ICultureFeed $cultureFeedTest,
+        \ICultureFeed $cultureFeed,
+        UitIdUserInterface $user,
+        IntegrationTypeStorageInterface $integrationTypeStorage
+    ) {
         $this->eventBus = $eventBus;
         $this->entityManager = $entityManager;
         $this->cultureFeedTest = $cultureFeedTest;
         $this->cultureFeed = $cultureFeed;
         $this->user = $user;
-        $this->permissionGroups = $permissionGroups;
+        $this->integrationTypeStorage = $integrationTypeStorage;
     }
 
     /**
@@ -73,6 +72,12 @@ class CreateProjectCommandHandler
      */
     public function handle(CreateProject $createProject)
     {
+        $integrationTypeId = $createProject->getIntegrationType();
+        $integrationType = $this->integrationTypeStorage->load($integrationTypeId);
+        if (!$integrationType) {
+            throw new \RuntimeException("Cannot create project for unknown integration type ({$integrationTypeId}).");
+        }
+
         // Prepare project.
         $project = new Project();
         $project->setName($createProject->getName());
@@ -84,7 +89,7 @@ class CreateProjectCommandHandler
         $project->setStatus(Project::PROJECT_STATUS_APPLICATION_SENT);
 
         // Create the test consumer.
-        $testConsumer = $this->createTestConsumer($createProject);
+        $testConsumer = $this->createTestConsumer($createProject, $integrationType);
 
         /** @var \CultureFeed_Consumer $cultureFeedConsumer */
         $project->setTestConsumerKey($testConsumer->consumerKey);
@@ -96,13 +101,10 @@ class CreateProjectCommandHandler
             $createConsumer = new \CultureFeed_Consumer();
             $createConsumer->name = $createProject->getName();
             $createConsumer->description = $createProject->getDescription();
-            $createConsumer->group = [$this->permissionGroups['default_consumer'], $createProject->getIntegrationType()];
-            if ($createProject->getIntegrationType() === $this->permissionGroups['entry_v3']) {
-                $createConsumer->group[] = $this->permissionGroups['auth0_refresh_token'];
-            }
+            $createConsumer->group = $integrationType->getUitIdPermissionGroups();
             $cultureFeedLiveConsumer = $this->cultureFeed->createServiceConsumer($createConsumer);
             // Add uitpas permission to consumer
-            $this->cultureFeed->addUitpasPermission($cultureFeedLiveConsumer, $this->permissionGroups['uitpas']);
+            $this->cultureFeed->addUitpasPermission($cultureFeedLiveConsumer, $integrationType->getUitPasPermissionGroups());
             $project->setStatus(Project::PROJECT_STATUS_ACTIVE);
             $project->setLiveConsumerKey($cultureFeedLiveConsumer->consumerKey);
             $project->setLiveApiKeySapi3($cultureFeedLiveConsumer->apiKeySapi3);
@@ -173,9 +175,8 @@ class CreateProjectCommandHandler
      * Create the test consumer, and add the user as admin.
      * @param CreateProject $createProject
      */
-    private function createTestConsumer(CreateProject $createProject)
+    private function createTestConsumer(CreateProject $createProject, IntegrationType $integrationType)
     {
-
         // Make sure the user also exists on test.
         $uid = $this->createTestUser($this->user->getUsername(), $this->user->mbox);
 
@@ -183,15 +184,14 @@ class CreateProjectCommandHandler
         $createConsumer = new \CultureFeed_Consumer();
         $createConsumer->name = $createProject->getName();
         $createConsumer->description = $createProject->getDescription();
-        $integrationType = $createProject->getIntegrationType();
-        $createConsumer->group = $this->permissionGroups[$integrationType]['uitid'];
+        $createConsumer->group = $integrationType->getUitIdPermissionGroups();
         $cultureFeedConsumer = $this->cultureFeedTest->createServiceConsumer($createConsumer);
 
         // Add the user as service consumer admin.
         $this->cultureFeedTest->addServiceConsumerAdmin($cultureFeedConsumer->consumerKey, $uid);
 
         // Add uitpas permission to consumer
-        $this->cultureFeedTest->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups[$integrationType]['uitpas']);
+        $this->cultureFeedTest->addUitpasPermission($cultureFeedConsumer, $integrationType->getUitPasPermissionGroups());
 
         return $cultureFeedConsumer;
     }

--- a/src/Project/CommandHandler/CreateProjectCommandHandler.php
+++ b/src/Project/CommandHandler/CreateProjectCommandHandler.php
@@ -183,16 +183,15 @@ class CreateProjectCommandHandler
         $createConsumer = new \CultureFeed_Consumer();
         $createConsumer->name = $createProject->getName();
         $createConsumer->description = $createProject->getDescription();
-        $integrationType =  $createProject->getIntegrationType();
-        $createConsumer->group = $this->permissionGroups[$integrationType];
-
+        $integrationType = $createProject->getIntegrationType();
+        $createConsumer->group = $this->permissionGroups[$integrationType]['uitid'];
         $cultureFeedConsumer = $this->cultureFeedTest->createServiceConsumer($createConsumer);
 
         // Add the user as service consumer admin.
         $this->cultureFeedTest->addServiceConsumerAdmin($cultureFeedConsumer->consumerKey, $uid);
 
         // Add uitpas permission to consumer
-        $this->cultureFeedTest->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups[22678]);
+        $this->cultureFeedTest->addUitpasPermission($cultureFeedConsumer, $this->permissionGroups[$integrationType]['uitpas']);
 
         return $cultureFeedConsumer;
     }

--- a/test/Project/CommandHandler/ActivateProjectCommandHandlerTest.php
+++ b/test/Project/CommandHandler/ActivateProjectCommandHandlerTest.php
@@ -83,7 +83,7 @@ class ActivateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
           'default_consumer' => 3,
           'uitpas' => 22678,
           'auth0_refresh_token' => 24640,
-          'entry_v3' => 24380
+          'entry_v3' => 24380,
         ];
 
         $this->commandHandler = new ActivateProjectCommandHandler($this->eventBus, $this->entityManager, $this->cultureFeed, $this->user, $this->permissionGroups);

--- a/test/Project/CommandHandler/ActivateProjectCommandHandlerTest.php
+++ b/test/Project/CommandHandler/ActivateProjectCommandHandlerTest.php
@@ -79,8 +79,14 @@ class ActivateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->user = $this->getMock(User::class);
         $this->user->id = 123;
+        $this->permissionGroups = [
+          'default_consumer' => 3,
+          'uitpas' => 22678,
+          'auth0_refresh_token' => 24640,
+          'entry_v3' => 24380
+        ];
 
-        $this->commandHandler = new ActivateProjectCommandHandler($this->eventBus, $this->entityManager, $this->cultureFeed, $this->user, 3, 22678);
+        $this->commandHandler = new ActivateProjectCommandHandler($this->eventBus, $this->entityManager, $this->cultureFeed, $this->user, $this->permissionGroups);
     }
 
     /**

--- a/test/Project/CommandHandler/ActivateProjectCommandHandlerTest.php
+++ b/test/Project/CommandHandler/ActivateProjectCommandHandlerTest.php
@@ -4,6 +4,8 @@ namespace CultuurNet\ProjectAanvraag\Project\CommandHandler;
 
 use CultuurNet\ProjectAanvraag\Entity\Coupon;
 use CultuurNet\ProjectAanvraag\Entity\ProjectInterface;
+use CultuurNet\ProjectAanvraag\IntegrationType\IntegrationType;
+use CultuurNet\ProjectAanvraag\IntegrationType\IntegrationTypeStorageInterface;
 use CultuurNet\ProjectAanvraag\Project\Command\ActivateProject;
 use CultuurNet\ProjectAanvraag\Project\Command\BlockProject;
 use CultuurNet\ProjectAanvraag\Project\Command\DeleteProject;
@@ -52,6 +54,11 @@ class ActivateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
     protected $project;
 
     /**
+     * @var IntegrationTypeStorageInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $integrationTypeStorage;
+
+    /**
      * {@inheritdoc}
      */
     public function setUp()
@@ -77,16 +84,24 @@ class ActivateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->project = $this->getMock(ProjectInterface::class);
 
+        $this->project
+            ->method('getGroupId')
+            ->willReturn(123);
+
+        $integrationType = new IntegrationType();
+        $integrationType->setUitIdPermissionGroups([3, 123]);
+        $integrationType->setUitPasPermissionGroups([]);
+
+        $this->integrationTypeStorage = $this->getMock(IntegrationTypeStorageInterface::class);
+        $this->integrationTypeStorage
+            ->method('load')
+            ->with(123)
+            ->willReturn($integrationType);
+
         $this->user = $this->getMock(User::class);
         $this->user->id = 123;
-        $this->permissionGroups = [
-          'default_consumer' => 3,
-          'uitpas' => 22678,
-          'auth0_refresh_token' => 24640,
-          'entry_v3' => 24380,
-        ];
 
-        $this->commandHandler = new ActivateProjectCommandHandler($this->eventBus, $this->entityManager, $this->cultureFeed, $this->user, $this->permissionGroups);
+        $this->commandHandler = new ActivateProjectCommandHandler($this->eventBus, $this->entityManager, $this->cultureFeed, $this->user, $this->integrationTypeStorage);
     }
 
     /**

--- a/test/Project/CommandHandler/CreateProjectCommandHandlerTest.php
+++ b/test/Project/CommandHandler/CreateProjectCommandHandlerTest.php
@@ -76,9 +76,15 @@ class CreateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
         $this->user->id = 123;
         $this->user->mbox = 'test@test.be';
         $this->user->nick = 'test';
+        $this->permissionGroups = [
+          'default_consumer' => 3,
+          'uitpas' => 22678,
+          'auth0_refresh_token' => 24640,
+          'entry_v3' => 24380
+        ];
 
         $this->commandHandler = $this->getMockBuilder(CreateProjectCommandHandler::class)
-            ->setConstructorArgs([$this->eventBus, $this->entityManager, $this->cultureFeedTest, $this->cultureFeed, $this->user, 3, 22678])
+            ->setConstructorArgs([$this->eventBus, $this->entityManager, $this->cultureFeedTest, $this->cultureFeed, $this->user, $this->permissionGroups])
             ->setMethods(['generatePassword'])
             ->getMock();
     }

--- a/test/Project/CommandHandler/CreateProjectCommandHandlerTest.php
+++ b/test/Project/CommandHandler/CreateProjectCommandHandlerTest.php
@@ -4,6 +4,8 @@ namespace CultuurNet\ProjectAanvraag\Project\CommandHandler;
 
 use CultuurNet\ProjectAanvraag\Entity\Coupon;
 use CultuurNet\ProjectAanvraag\Entity\Project;
+use CultuurNet\ProjectAanvraag\IntegrationType\IntegrationType;
+use CultuurNet\ProjectAanvraag\IntegrationType\IntegrationTypeStorageInterface;
 use CultuurNet\ProjectAanvraag\Project\Command\CreateProject;
 use CultuurNet\ProjectAanvraag\User\User;
 use CultuurNet\ProjectAanvraag\User\UserInterface;
@@ -44,6 +46,11 @@ class CreateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
     protected $user;
 
     /**
+     * @var IntegrationTypeStorageInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $integrationTypeStorage;
+
+    /**
      * {@inheritdoc}
      */
     public function setUp()
@@ -72,19 +79,23 @@ class CreateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('handle');
 
+        $integrationType = new IntegrationType();
+        $integrationType->setUitIdPermissionGroups([3, 123]);
+        $integrationType->setUitPasPermissionGroups([]);
+
+        $this->integrationTypeStorage = $this->getMock(IntegrationTypeStorageInterface::class);
+        $this->integrationTypeStorage
+            ->method('load')
+            ->with(123)
+            ->willReturn($integrationType);
+
         $this->user = new User();
         $this->user->id = 123;
         $this->user->mbox = 'test@test.be';
         $this->user->nick = 'test';
-        $this->permissionGroups = [
-          'default_consumer' => 3,
-          'uitpas' => 22678,
-          'auth0_refresh_token' => 24640,
-          'entry_v3' => 24380,
-        ];
 
         $this->commandHandler = $this->getMockBuilder(CreateProjectCommandHandler::class)
-            ->setConstructorArgs([$this->eventBus, $this->entityManager, $this->cultureFeedTest, $this->cultureFeed, $this->user, $this->permissionGroups])
+            ->setConstructorArgs([$this->eventBus, $this->entityManager, $this->cultureFeedTest, $this->cultureFeed, $this->user, $this->integrationTypeStorage])
             ->setMethods(['generatePassword'])
             ->getMock();
     }

--- a/test/Project/CommandHandler/CreateProjectCommandHandlerTest.php
+++ b/test/Project/CommandHandler/CreateProjectCommandHandlerTest.php
@@ -80,7 +80,7 @@ class CreateProjectCommandHandlerTest extends \PHPUnit_Framework_TestCase
           'default_consumer' => 3,
           'uitpas' => 22678,
           'auth0_refresh_token' => 24640,
-          'entry_v3' => 24380
+          'entry_v3' => 24380,
         ];
 
         $this->commandHandler = $this->getMockBuilder(CreateProjectCommandHandler::class)

--- a/test/Project/ProjectServiceTest.php
+++ b/test/Project/ProjectServiceTest.php
@@ -189,7 +189,7 @@ class ProjectServiceTest extends \PHPUnit_Framework_TestCase
     {
         /** @var Project|\PHPUnit_Framework_MockObject_MockObject $project */
         $project = $this->getMock(Project::class, ['enrichWithConsumerInfo']);
-        $integrationType = $this->getMock(IntegrationType::class);
+        $integrationType = new IntegrationType();
 
         $project->setName('name');
         $project->setLiveConsumerKey('live');


### PR DESCRIPTION
### Changed
- centralize permission groups in config 
- use centralized permission groups instead of seperate arguments in messagebus.yml + classes

### Added
- add auth0_refresh_token permission group to entry_api projects

### Fixed
- align integration types with test environment

---
Ticket: [https://jira.uitdatabank.be/browse/PROJ-140](https://jira.uitdatabank.be/browse/PROJ-140)