### PR TITLE
Update silex-uitid-provider commit to one that exists

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -445,12 +445,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cultuurnet/silex-uitid-provider.git",
-                "reference": "cecdb899dd4b1ac4334d0517d90551bcd3878be1"
+                "reference": "8cccb71d19687c3515d94a562d2ecf606a4ec500"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cultuurnet/silex-uitid-provider/zipball/cecdb899dd4b1ac4334d0517d90551bcd3878be1",
-                "reference": "cecdb899dd4b1ac4334d0517d90551bcd3878be1",
+                "url": "https://api.github.com/repos/cultuurnet/silex-uitid-provider/zipball/8cccb71d19687c3515d94a562d2ecf606a4ec500",
+                "reference": "8cccb71d19687c3515d94a562d2ecf606a4ec500",
                 "shasum": ""
             },
             "require": {
@@ -480,7 +480,7 @@
                 "GPL-3.0"
             ],
             "description": "Silex UiTID authentication provider.",
-            "time": "2016-10-28T15:50:42+00:00"
+            "time": "2020-06-15T10:16:14+00:00"
         },
         {
             "name": "cweagans/composer-patches",


### PR DESCRIPTION
### Fixed

- The 2.x version of silex-uitid-provider was deleted and later recovered from a copy in a local vendor folder. The commit has changed though so it needs to be updated to one that exists now.

---

Spotted this in a Travis build where it was loading the package from cache because it couldn't find the commit anymore, while reviewing another PR.

![Screenshot 2020-06-15 at 12 30 12](https://user-images.githubusercontent.com/959026/84647696-111c0380-af04-11ea-9c5f-9148fc56e757.png)