### PR TITLE
Only use lg format for single calendar type

### DIFF
--- a/src/Widget/Twig/TwigPreprocessor.php
+++ b/src/Widget/Twig/TwigPreprocessor.php
@@ -776,9 +776,13 @@ class TwigPreprocessor
 
         if ($event->getCalendarType() === Offer::CALENDAR_TYPE_MULTIPLE) {
             return $calendarFormatter->format($event, 'sm');
-        } else {
+        }
+
+        if ($event->getCalendarType() === Offer::CALENDAR_TYPE_SINGLE) {
             return $calendarFormatter->format($event, 'lg');
         }
+
+        return $calendarFormatter->format($event, 'md');
     }
 
     /**


### PR DESCRIPTION
### Fixed

- Only use `lg` format for `single` calendar type, not `periodic` and `permanent`

---
Ticket: https://jira.uitdatabank.be/browse/WID-351
Follow-up to: #206 