### PR TITLE
WID-375 Encode the URL parameters to make sure brackets are encoded

### DIFF
--- a/web/assets/js/widgets/core/widgets.js
+++ b/web/assets/js/widgets/core/widgets.js
@@ -387,7 +387,7 @@ window.CultuurnetWidgets = window.CultuurnetWidgets || { behaviors: {} };
           newParams.push(key + '=' + value);
         });
 
-        return newParams.join('&');
+        return encodeURI(newParams.join('&'));
     };
 
     CultuurnetWidgets.addLoadEvent = function(func) {


### PR DESCRIPTION
### Fixed
- Encode the URL parameters to make sure brackets are encoded for servers who don't support plain square brackets inside the URL parameters
---
Ticket: https://jira.uitdatabank.be/browse/WID-375