### PR TITLE
Remove unnecessary wrapping of culturefeed consumer key and secret

### DIFF
--- a/app/Core/CultureFeedServiceProvider.php
+++ b/app/Core/CultureFeedServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace CultuurNet\ProjectAanvraag\Core;
 
-use CultuurNet\Auth\ConsumerCredentials;
 use CultuurNet\UiTIDProvider\CultureFeed\CultureFeedServiceProvider as CultureFeedServiceProviderOriginal;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
@@ -17,26 +16,14 @@ class CultureFeedServiceProvider extends CultureFeedServiceProviderOriginal impl
         // Register live.
         parent::register($pimple);
 
-        // Register test.
-        $pimple['culturefeed_test_consumer_credentials'] = function (Container $pimple) {
-            return new ConsumerCredentials(
-                $pimple['culturefeed_test.consumer.key'],
-                $pimple['culturefeed_test.consumer.secret']
-            );
-        };
-
         $pimple['culturefeed_test'] = function (Container $pimple) {
             return new \CultureFeed($pimple['culturefeed_test_oauth_client']);
         };
 
         $pimple['culturefeed_test_oauth_client'] = function (Container $pimple) {
-            /* @var ConsumerCredentials $consumerCredentials */
-            $consumerCredentials = $pimple['culturefeed_test_consumer_credentials'];
-
-
             $oauthClient = new \CultureFeed_DefaultOAuthClient(
-                $consumerCredentials->getKey(),
-                $consumerCredentials->getSecret()
+                $pimple['culturefeed_test.consumer.key'],
+                $pimple['culturefeed_test.consumer.secret']
             );
             $oauthClient->setEndpoint($pimple['culturefeed_test.endpoint']);
 


### PR DESCRIPTION
### Removed

- Removed unnecessary `ConsumerCredentials` usage. We cannot remove `cultuurnet/auth` yet because we still use `cultuurnet/silex-uitid-provider`, but we will be able to remove that when we switch to Auth0 for login.