### PR TITLE
PROJ-195 Rename Coupon_field__c to Coupon__c as on production

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,10 @@
         "test": "vendor/bin/phpunit",
         "test:integrations:insightly": "vendor/bin/phpunit --configuration phpunit.integrations.insightly.xml",
         "phpstan": "vendor/bin/phpstan",
-        "phpcs": "vendor/bin/phpcs --standard=phpcs-ruleset.xml app/ src/ test/",
+        "phpcs": [
+            "vendor/bin/phpcs --config-set installed_paths vendor/escapestudios/symfony2-coding-standard",
+            "vendor/bin/phpcs --standard=phpcs-ruleset.xml app/ src/ test/"
+        ],
         "ci": [
             "composer validate",
             "composer phpcs",

--- a/src/Integrations/Insightly/Serializers/CustomFieldSerializer.php
+++ b/src/Integrations/Insightly/Serializers/CustomFieldSerializer.php
@@ -12,7 +12,7 @@ use CultuurNet\ProjectAanvraag\Integrations\Insightly\ValueObjects\TaxNumber;
 final class CustomFieldSerializer
 {
     private const CUSTOM_FIELD_INTEGRATION_TYPE = 'Product__c';
-    private const CUSTOM_FIELD_COUPON = 'Coupon_field__c';
+    private const CUSTOM_FIELD_COUPON = 'Coupon__c';
     public const CUSTOM_FIELD_EMAIL = 'Email_boekhouding__c';
     public const CUSTOM_FIELD_TAX_NUMBER = 'BTW_nummer__c';
 


### PR DESCRIPTION
### Fixed
- Fixed name for coupon field on production, needs to be `Coupon__c`
---
Ticket: https://jira.uitdatabank.be/browse/PROJ-195