### PR TITLE
WID-459 - Fix loading of searchresults when using anchor in url

### DIFF
--- a/web/assets/js/widgets/core/widgets.js
+++ b/web/assets/js/widgets/core/widgets.js
@@ -235,7 +235,7 @@ window.CultuurnetWidgets = window.CultuurnetWidgets || { behaviors: {} };
 
         // Only render the widget if it's a known id.
         if (CultuurnetWidgetsSettings[widgetPageId].widgetMapping && CultuurnetWidgetsSettings[widgetPageId].widgetMapping.hasOwnProperty(widgetId)) {
-            return CultuurnetWidgets.apiRequest(CultuurnetWidgetsSettings[widgetPageId].apiUrl + '/render/' + CultuurnetWidgetsSettings[widgetPageId].widgetMapping[widgetId] + '/' + widgetId + '/search-results-with-facets' + '?origin=' + origin );
+            return CultuurnetWidgets.apiRequest(CultuurnetWidgetsSettings[widgetPageId].apiUrl + '/render/' + CultuurnetWidgetsSettings[widgetPageId].widgetMapping[widgetId] + '/' + widgetId + '/search-results-with-facets' + '?origin=' + encodeURIComponent(origin));
         }
         else {
             deferred.reject('The given widget id was not found');


### PR DESCRIPTION
### Fixed
- loading of searchresults when using anchor in url

http://localhost:8000/#random

Before:
<img width="1356" alt="Screenshot 2022-01-11 at 11 07 01" src="https://user-images.githubusercontent.com/9402377/148925444-d890c730-8525-4cb1-9cf8-503e15b61dc6.png">


After:
<img width="1357" alt="Screenshot 2022-01-11 at 11 06 13" src="https://user-images.githubusercontent.com/9402377/148925448-ab4aca56-683a-44e6-ab0d-11cc9aa8d54d.png">



---
Ticket: https://jira.uitdatabank.be/browse/WID-459