### PR TITLE
WID-478 - Transform activeSeconds to integer to match snowplow scheme

### DIFF
--- a/web/assets/js/widgets/core/snowplow-tracking.js
+++ b/web/assets/js/widgets/core/snowplow-tracking.js
@@ -174,12 +174,13 @@
 
   window.addEventListener("beforeunload", (event) => {
     const timeSpent = getTimeSpentInSeconds();
+    const activeSeconds = Math.round(timeSpent);
 
     window.snowplow("trackSelfDescribingEvent", {
       event: {
         schema: "iglu:be.general/page_unload/jsonschema/1-0-0",
         data: {
-          active_seconds: timeSpent,
+          active_seconds: activeSeconds,
         },
       },
     });


### PR DESCRIPTION
### Fixed
- Snowplow error: `$.active_seconds: number found, integer expected\", \"path\": \"$.active_seconds\"`

---
Ticket:  https://jira.uitdatabank.be/browse/WID-478