### PR TITLE
WID-507 - use camera icon for online participation url

### DIFF
--- a/views/widgets/event-summary.html.twig
+++ b/views/widgets/event-summary.html.twig
@@ -96,11 +96,7 @@
                     {% if settings_items.where.label is not empty %}
                         <div class="list-item-aside">
                             <em class="cnw_searchresult-detail-label">{{ settings_items.where.label }}</em>
-                            {% if event.attendanceMode is same as('online') %}
-                                <i class="cnw-fa cnw-fa-video-camera"></i>
-                            {% else %}
-                                <i class="cnw-fa cnw-fa-map-marker"></i>
-                            {% endif %}
+                            <i class="cnw-fa cnw-fa-map-marker"></i>
                         </div>
                         <div class="list-item-content">
                             {% if event.attendanceMode is same as('online') %}

--- a/views/widgets/search-results-widget/detail-page.html.twig
+++ b/views/widgets/search-results-widget/detail-page.html.twig
@@ -117,6 +117,7 @@
                     {% if event.onlineUrl is not empty%}
                         <dt>
                             <em class="cnw_searchresult-detail-label">{{ 'event_online_participation' | transTo(preferredLanguage) }}</em>
+                            <i class="cnw-fa cnw-fa-video-camera"></i>
                         </dt>
                         <dd>
                             <a href="{{ event.onlineUrl }}" target="_blank">{{ event.onlineUrl }}</a>

--- a/views/widgets/search-results-widget/detail-page.html.twig
+++ b/views/widgets/search-results-widget/detail-page.html.twig
@@ -94,11 +94,7 @@
                     {% if settings.where.enabled and event.where %}
                     <dt>
                         <em class="cnw_searchresult-detail-label">{{ settings.where.label }}</em>
-                        {% if event.attendanceMode is same as('online') %}
-                            <i class="cnw-fa cnw-fa-video-camera"></i>
-                        {% else %}
-                            <i class="cnw-fa cnw-fa-map-marker"></i>
-                        {% endif %}
+                        <i class="cnw-fa cnw-fa-map-marker"></i>
                     </dt>
                     <dd>
                         {% if event.attendanceMode is same as('online') %}


### PR DESCRIPTION
### Changed
- Readd `map` icon for location
- Use `camera` icon for participation url
<img width="1422" alt="Screenshot 2022-09-07 at 14 08 12" src="https://user-images.githubusercontent.com/9402377/188875693-1a2c3228-3f31-4e12-9656-c6f41a811c4c.png">

---
Ticket: https://jira.uitdatabank.be/browse/WID-507