### PR TITLE
Add automated dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Added

- Automated dependency updates

This needs to be enabled in the project settings. Once enabled, automated updates will be suggested by dependabot.

Note: this differs from the Dependabot security updates that are already in place. It will also bump major versions of dependencies.

Please see the documentation for all configuration options: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates

---
Ticket: