### PR TITLE
WID-543 - Add X-Client-Properties to default headers sent with the SearchAPIClient

### DIFF
--- a/app/SearchAPI/SearchAPIServiceProvider.php
+++ b/app/SearchAPI/SearchAPIServiceProvider.php
@@ -20,6 +20,7 @@ class SearchAPIServiceProvider extends APIServiceProviderBase
                     'base_uri' => $pimple['search_api.base_url'],
                     'headers' => [
                         'X-Api-Key' => $pimple['search_api.api_key'],
+                        'X-Client-Properties' => 'cluster|widgets, cluster|snowplow',
                     ],
                     'handler' => $this->getHandlerStack('search_api', $pimple),
                 ]


### PR DESCRIPTION
### Added

- Add X-Client-Properties to default headers sent with the SearchAPIClient
---
Ticket: https://jira.uitdatabank.be/browse/WID-543