### PR TITLE
PPF-192 enable/disable delay via config

### DIFF
--- a/app/ConsoleApplication.php
+++ b/app/ConsoleApplication.php
@@ -71,7 +71,9 @@ class ConsoleApplication extends ApplicationBase
         $consoleApp = $this['console'];
 
         $consoleApp->add(new CacheClearCommand());
-        $consoleApp->add(new ConsumeCommand('projectaanvraag:consumer', 'rabbit.connection', 'rabbit.consumer'));
+
+        $disableDelay = $this['config']['rabbitmq']['disable_delay'] ?? false;
+        $consoleApp->add(new ConsumeCommand('projectaanvraag:consumer', 'rabbit.connection', 'rabbit.consumer', $disableDelay));
 
         // Sync culturefeed consumers with local DB
         $consoleApp->add(new SyncConsumersCommand());

--- a/app/Core/MessageBusProvider.php
+++ b/app/Core/MessageBusProvider.php
@@ -119,13 +119,8 @@ class MessageBusProvider implements ServiceProviderInterface, EventListenerProvi
                 [
                     'declare' => true,
                     'name' => 'main_exchange',
-                    'type' => 'x-delayed-message',
+                    'type' => 'topic',
                     'durable' => true,
-                    'arguments' => new AMQPTable(
-                        [
-                            'x-delayed-type' => 'direct',
-                        ]
-                    ),
                 ]
             );
 

--- a/src/Console/Command/ConsumeCommand.php
+++ b/src/Console/Command/ConsumeCommand.php
@@ -28,16 +28,23 @@ class ConsumeCommand extends Command
     protected $connectionId;
 
     /**
+     * @var boolean
+     */
+    protected $disableDelay;
+
+    /**
      * ConsumeCommand constructor.
      * @param null|string $name
      * @param $connectionId
      * @param $consumerId
+     * @param bool $disableDelay
      */
-    public function __construct($name, $connectionId, $consumerId)
+    public function __construct($name, $connectionId, $consumerId, $disableDelay = false)
     {
         parent::__construct($name);
         $this->connectionId = $connectionId;
         $this->consumerId = $consumerId;
+        $this->disableDelay = $disableDelay;
     }
 
     /**
@@ -73,7 +80,11 @@ class ConsumeCommand extends Command
         $channel = $connection->channel();
 
         // Declare the exchange
-        $channel->exchange_declare('main_exchange', 'x-delayed-message', false, true, false, false, false);
+        if (!$this->disableDelay) {
+            $channel->exchange_declare('main_exchange', 'x-delayed-message', false, true, false, false, false, new AMQPTable(['x-delayed-type' => 'direct']));
+        } else {
+            $channel->exchange_declare('main_exchange', 'topic', false, true, false);
+        }
 
         // Declare the main queue
         $channel->queue_declare('projectaanvraag', false, true, false, false, false, new AMQPTable(['routing_keys' => ['asynchronous_commands']]));

--- a/src/Console/Command/ConsumeCommand.php
+++ b/src/Console/Command/ConsumeCommand.php
@@ -73,7 +73,7 @@ class ConsumeCommand extends Command
         $channel = $connection->channel();
 
         // Declare the exchange
-        $channel->exchange_declare('main_exchange', 'x-delayed-message', false, true, false, false, false, new AMQPTable(['x-delayed-type' => 'direct']));
+        $channel->exchange_declare('main_exchange', 'x-delayed-message', false, true, false, false, false);
 
         // Declare the main queue
         $channel->queue_declare('projectaanvraag', false, true, false, false, false, new AMQPTable(['routing_keys' => ['asynchronous_commands']]));


### PR DESCRIPTION
### Removed

- Added support for enabling/disabling `delay` for `amqp`-messages via `config`

---
Ticket: https://jira.publiq.be/browse/PPF-192