### PR TITLE
Disable dependabot for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # TEMP: disable dependabot PR's, till code is cleaned a bit more
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### Changed

- Temporarily set the limit of open `dependabot`-PR's to `0`, thus preventing `dependabot` from opening new PR's.
