### PR TITLE
PPF-423: Allow both trailing & no trailing slash when importing projects from PPF

### DIFF
--- a/app/Project/ProjectControllerProvider.php
+++ b/app/Project/ProjectControllerProvider.php
@@ -55,6 +55,7 @@ class ProjectControllerProvider implements ControllerProviderInterface
         $controllers->put('/{id}/organisation', 'project_controller:updateOrganisation');
 
         $controllers->post('/{uuid}', 'import_project_controller:importProject');
+        $controllers->post('/{uuid}/', 'import_project_controller:importProject');
         $controllers->get('/{uuid}/widget/', 'open_project_controller:openProject');
 
         return $controllers;


### PR DESCRIPTION
### Changed

- `ProjectControllerProvider`: make trailing slash optional when importing Projects from PPF.

### Fixed

- No more CORS-errors, when trying to create or open Widgets from PPF.

---
Ticket: https://jira.publiq.be/browse/PPF-423