### PR TITLE
WID-569 - Fix wrong url passed to articleLinker

### DIFF
--- a/src/Widget/Controller/WidgetController.php
+++ b/src/Widget/Controller/WidgetController.php
@@ -151,6 +151,8 @@ class WidgetController
         $project = $this->projectConverter->convert($widgetPage->getProjectId());
 
         if ($cdbid && $request->headers->get('referer')) {
+            var_dump($request->query);
+            die();
             $url = $request->headers->get('referer');
 
             $cdbidsArr = explode(' ', $cdbid);

--- a/src/Widget/Controller/WidgetController.php
+++ b/src/Widget/Controller/WidgetController.php
@@ -148,13 +148,11 @@ class WidgetController
      */
     public function renderWidget(Request $request, WidgetPageInterface $widgetPage, $widgetId, $cdbid = '')
     {
+
         $project = $this->projectConverter->convert($widgetPage->getProjectId());
 
-        if ($cdbid && $request->headers->get('referer')) {
-            var_dump($request->query);
-            die();
-            $url = $request->headers->get('referer');
-
+        if ($cdbid && $request->query->get('origin')) {
+            $url = $request->query->get('origin');
             $cdbidsArr = explode(' ', $cdbid);
             foreach ($cdbidsArr as $id) {
                 $this->commandBus->handle(new CreateArticleLink($url, $id));


### PR DESCRIPTION
### Changed
- Use `origin`which is passed as an url param instead of the header referer. 
Since the referer is not reliable: the path is truncated from the referer. 

### Fixed:
- This should fix the issue in which articles are linked to the homepage.

---
Ticket: https://jira.publiq.be/browse/WID-569