### PR TITLE
Import `WidgetType` to avoid runtime error

### DIFF
--- a/src/Widget/WidgetType/Facets.php
+++ b/src/Widget/WidgetType/Facets.php
@@ -14,6 +14,7 @@ use CultuurNet\SearchV3\SearchQueryInterface;
 use CultuurNet\SearchV3\ValueObjects\PagedCollection;
 use Pimple\Container;
 use Symfony\Component\HttpFoundation\RequestStack;
+use CultuurNet\ProjectAanvraag\Widget\WidgetType;
 
 /**
  * Provides the facets widget type.


### PR DESCRIPTION
### Fixed
- Import `WidgetType` to avoid runtime error