### PR TITLE
WID-588 - Improve autocomplete results for provinces

### DIFF
--- a/src/Widget/RegionService.php
+++ b/src/Widget/RegionService.php
@@ -125,8 +125,9 @@ class RegionService
         uasort(
             $matches,
             function ($a, $b) {
-                // Reverse the result using *-1 so higher scores are sorted before lower scores (instead of after)
-                return ($a['score'] <=> $b['score']) * -1;
+                // Reverse the comparison so that matches with a higher score are sorted before matches with a lower
+                // score
+                return $b['score'] <=> $a['score'];
             }
         );
 

--- a/src/Widget/RegionService.php
+++ b/src/Widget/RegionService.php
@@ -10,6 +10,13 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class RegionService
 {
+    private const SCORE_EXACT = 6; // Exact match
+    private const SCORE_EXACT_SUFFIX_PREFIX = 5; // Matches like `Regio X`, `Provincie X`, or `X + deelgemeenten` for search string `X`
+    private const SCORE_TYPEAHEAD_COMPLETE = 4; // Typeahead match with a whitespace afterward, e.g. `Zele (Zele)` for search string `Zele`
+    private const SCORE_TYPEAHEAD_PARTIAL = 3; // Typeahead match with a non-whitespace character afterward, e.g. `Zelem (Halen)` for search string `Zele`
+    private const SCORE_SUBSTRING = 2; // If the search string is not at the start but after a ( or -, e.g. `Hypothetical example (Zele)` for search string `Zele`
+    private const SCORE_PARTIAL = 1; // Other partial match, e.g. `Balegem (Oosterzele)` or `Elzele + deelgemeente` for search string `Zele`
+
     /**
      * @var string
      */
@@ -48,23 +55,88 @@ class RegionService
                     }
                 }
                 $compareString = strtolower($translatedRegion);
-                // This is done to find cities & towns with short names which also match lots of other cities & towns
-                // e.g., Zele or Egem
-                if (strpos($compareString, $searchString) !== false) {
-                    $matches[$region->key] = $translatedRegion;
+
+                // We compare the strings in multiple ways and give a score based on the kind of match, to avoid that
+                // when you search for cities or towns with short names you first get a lot of irrelevant matches that
+                // also contain that name or even that they are completely ommited because of a visual limit in the FE.
+                // (E.g. Zele or Egem)
+                // @see https://jira.publiq.be/browse/WID-575
+                // @see https://jira.publiq.be/browse/WID-588
+
+                // Exact matches get the highest relevancy score
+                if ($compareString === $searchString) {
+                    $matches[$region->key] = [
+                        'score' => self::SCORE_EXACT,
+                        'name'  => $translatedRegion,
+                    ];
+                    continue;
                 }
-                // This is done to add the submunicipalities when searching for a municipality.
-                if (strpos($compareString, '(' . $searchString) !== false) {
-                    $matches[$region->key] = $translatedRegion;
+
+                // Exact matches with a known suffix / prefix like `Regio X`, `X + deelgemeenten`, ... get the 2nd
+                // highest score. (Keep in mind that everything is already converted to lowercase)
+                // Otherwise "Provincie Antwerpen" would get buried by all subminicipalities of Antwerpen
+                if ($compareString === 'regio ' . $searchString ||
+                    $compareString === $searchString . ' + deelgemeenten' ||
+                    $compareString === 'provincie ' . $searchString) {
+                    $matches[$region->key] = [
+                        'score' => self::SCORE_EXACT_SUFFIX_PREFIX,
+                        'name'  => $translatedRegion,
+                    ];
+                    continue;
                 }
-                // This is done to add informal municipality names without prefixes like Saint
-                if (strpos($compareString, '-' . $searchString) !== false) {
-                    $matches[$region->key] = $translatedRegion;
+
+                // Typeahead matches get the 3rd / 4th highest relevancy score based on the character
+                // after the match
+                $position = strpos($compareString, $searchString);
+                if ($position === 0) {
+                    // If the character after the match is a space, give it a higher score than if it's a non-whitespace
+                    // character.
+                    // e.g. `Zele (Zele)` is more likely to be relevant than `Zelem (Halen)` for a search on `Zele`
+                    $nextCharacter = $compareString[$position + strlen($searchString)];
+                    $matches[$region->key] = [
+                        'score' => $nextCharacter === ' ' ? self::SCORE_TYPEAHEAD_COMPLETE : self::SCORE_TYPEAHEAD_PARTIAL,
+                        'name'  => $translatedRegion,
+                    ];
+                    continue;
+                }
+
+                // We also promote matches that are not at the start of the string but after a `(` or `-`
+                // to have better support for submunicipalities (like "Kessel-Lo (Leuven)" for the query "Leuven")
+                // and municipality names with prefixes like Saint (like "Sint-Amands" for the query "Amands")
+                if ($position !== false && $position > 0 && in_array($compareString[$position-1], ['(', '-'])) {
+                    $matches[$region->key] = [
+                        'score' => self::SCORE_SUBSTRING,
+                        'name'  => $translatedRegion,
+                    ];
+                    continue;
+                }
+
+                // Generic partial matches get the lowest relevancy score (but are also included)
+                if ($position !== false) {
+                    $matches[$region->key] = [
+                        'score' => self::SCORE_PARTIAL,
+                        'name'  => $translatedRegion,
+                    ];
                 }
             }
         }
 
-        return $matches;
+        // Sort the matches by score (but keep the keys)
+        uasort(
+            $matches,
+            function ($a, $b) {
+                // Reverse the result using *-1 so higher scores are sorted before lower scores (instead of after)
+                return ($a['score'] <=> $b['score']) * -1;
+            }
+        );
+
+        // Convert the matches to string values before returning
+        return array_map(
+            function ($match) {
+                return $match['name'];
+            },
+            $matches
+        );
     }
 
     /**

--- a/src/Widget/RegionService.php
+++ b/src/Widget/RegionService.php
@@ -50,7 +50,7 @@ class RegionService
                 $compareString = strtolower($translatedRegion);
                 // This is done to find cities & towns with short names which also match lots of other cities & towns
                 // e.g., Zele or Egem
-                if (strpos($compareString, $searchString) === 0) {
+                if (strpos($compareString, $searchString) !== false) {
                     $matches[$region->key] = $translatedRegion;
                 }
                 // This is done to add the submunicipalities when searching for a municipality.

--- a/test/Widget/RegionServiceTest.php
+++ b/test/Widget/RegionServiceTest.php
@@ -22,17 +22,18 @@ final class RegionServiceTest extends TestCase
      */
     public function it_will_show_submunicipalities(): void
     {
-        $this->assertEquals(
+        $this->assertAutocompleteMatches(
             [
-                'nis-25117D' => 'Gentinnes (Chastre)',
                 'nis-44021' => 'Gent + deelgemeenten',
+                'reg-gent' => 'Regio Gent',
                 'nis-44021-Z' => 'Gent (Gent)',
-                'nis-44021D-II' => 'Mendonk (Gent)',
+                'nis-25117D' => 'Gentinnes (Chastre)',
+                'nis-44021F' => 'Gentbrugge (Gent)',
                 'nis-44021D-III' => 'Desteldonk (Gent)',
                 'nis-44021D-IV' => 'Oostakker (Gent)',
                 'nis-44021D-I' => 'Sint-Kruis-Winkel (Gent)',
                 'nis-44021E' => 'Sint-Amandsberg (Gent)',
-                'nis-44021F' => 'Gentbrugge (Gent)',
+                'nis-44021D-II' => 'Mendonk (Gent)',
                 'nis-44021H' => 'Zwijnaarde (Gent)',
                 'nis-44021G' => 'Ledeberg (Gent)',
                 'nis-44021J-II' => 'Afsnee (Gent)',
@@ -40,6 +41,8 @@ final class RegionServiceTest extends TestCase
                 'nis-44021K' => 'Drongen (Gent)',
                 'nis-44021L' => 'Mariakerke (Gent)',
                 'nis-44021M' => 'Wondelgem (Gent)',
+                'nis-62079C' => 'Hermalle-sous-Argenteau (Oupeye)',
+                'nis-62108C' => 'Argenteau (Wezet)',
             ],
             $this->regionService->getAutocompletResults('Gent')
         );
@@ -50,11 +53,41 @@ final class RegionServiceTest extends TestCase
      */
     public function it_will_find_match_the_start_of_a_city_name()
     {
-        $this->assertEquals(
+        $this->assertAutocompleteMatches(
             [
                 'nis-42028' => 'Zele + deelgemeenten',
                 'nis-42028A' => 'Zele (Zele)',
                 'nis-71020B' => 'Zelem (Halen)',
+                'nis-41027E' => 'Woubrechtegem (Herzele)',
+                'nis-51017C' => 'Lahamaide (Elzele)',
+                'nis-51017A' => 'Ellezelles (Elzele)',
+                'nis-51017B' => 'Wodecq (Elzele)',
+                'nis-51017' => 'Elzele + deelgemeenten',
+                'nis-41034B' => 'Wanzele (Lede)',
+                'nis-44052F' => 'Gijzenzele (Oosterzele)',
+                'nis-44052E' => 'Landskouter (Oosterzele)',
+                'nis-44052D' => 'Moortsele (Oosterzele)',
+                'nis-44052C' => 'Scheldewindeke (Oosterzele)',
+                'nis-44052A' => 'Oosterzele (Oosterzele)',
+                'nis-44052B' => 'Balegem (Oosterzele)',
+                'nis-44052' => 'Oosterzele + deelgemeenten',
+                'nis-12030D' => 'Liezele (Puurs-Sint-Amands)',
+                'nis-23023B' => 'Vollezele (Galmaarden)',
+                'nis-41027G' => 'Steenhuize-Wijnhuize (Herzele)',
+                'nis-41027F' => 'Sint-Antelinks (Herzele)',
+                'nis-41027D' => 'Ressegem (Herzele)',
+                'nis-41027B' => 'Hillegem (Herzele)',
+                'nis-41027C' => 'Borsbeke (Herzele)',
+                'nis-41027A' => 'Herzele (Herzele)',
+                'nis-41027' => 'Herzele + deelgemeenten',
+                'nis-41063D' => 'Vlierzele (Sint-Lievens-Houtem)',
+                'nis-41018C' => 'Onkerzele (Geraardsbergen)',
+                'nis-33011J' => 'Voormezele (Ieper)',
+                'nis-36012B' => 'Dadizele (Moorslede)',
+                'nis-37018B' => 'Zwevezele (Wingene)',
+                'nis-31005C' => 'Dudzele (Brugge)',
+                'nis-23060B' => 'Mazenzele (Opwijk)',
+                'nis-41027H' => 'Sint-Lievens-Esse (Herzele)',
             ],
             $this->regionService->getAutocompletResults('Zele')
         );
@@ -65,11 +98,11 @@ final class RegionServiceTest extends TestCase
      */
     public function it_will_match_with_informal_names(): void
     {
-        $this->assertEquals(
+        $this->assertAutocompleteMatches(
             [
+                'nis-24008C' => 'Molenbeek-Wersbeek (Bekkevoort)',
                 'nis-21012' => 'Sint-Jans-Molenbeek + deelgemeenten',
                 'nis-21012A' => 'Sint-Jans-Molenbeek (Sint-Jans-Molenbeek)',
-                'nis-24008C' => 'Molenbeek-Wersbeek (Bekkevoort)',
             ],
             $this->regionService->getAutocompletResults('Molenbeek')
         );
@@ -98,5 +131,15 @@ final class RegionServiceTest extends TestCase
             null,
             $this->regionService->getItemByName('Liezele')
         );
+    }
+
+    /**
+     * First asserts that the keys and values of the two arrays are the same, and then asserts that the order of the
+     * values is as expected
+     */
+    private function assertAutocompleteMatches(array $expected, array $actual): void
+    {
+        $this->assertEquals($expected, $actual);
+        $this->assertEquals(array_values($expected), array_values($actual));
     }
 }

--- a/test/Widget/RegionServiceTest.php
+++ b/test/Widget/RegionServiceTest.php
@@ -96,6 +96,22 @@ final class RegionServiceTest extends TestCase
     /**
      * @test
      */
+    public function it_will_find_match_provinces()
+    {
+        $this->assertAutocompleteMatches(
+            [
+                'nis-60000' => 'Provincie Luik',
+                'nis-62063' => 'Luik + deelgemeenten',
+                'nis-62063-Z' => 'Liège (Luik)',
+                'nis-62063E' => 'Bressoux (Luik)',
+            ],
+            $this->regionService->getAutocompletResults('Luik')
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_will_match_with_informal_names(): void
     {
         $this->assertAutocompleteMatches(

--- a/test/Widget/RegionServiceTest.php
+++ b/test/Widget/RegionServiceTest.php
@@ -22,7 +22,7 @@ final class RegionServiceTest extends TestCase
      */
     public function it_will_show_submunicipalities(): void
     {
-        $this->assertAutocompleteMatches(
+        $this->assertSame(
             [
                 'nis-44021' => 'Gent + deelgemeenten',
                 'reg-gent' => 'Regio Gent',
@@ -53,7 +53,7 @@ final class RegionServiceTest extends TestCase
      */
     public function it_will_find_match_the_start_of_a_city_name()
     {
-        $this->assertAutocompleteMatches(
+        $this->assertSame(
             [
                 'nis-42028' => 'Zele + deelgemeenten',
                 'nis-42028A' => 'Zele (Zele)',
@@ -98,7 +98,7 @@ final class RegionServiceTest extends TestCase
      */
     public function it_will_find_match_provinces()
     {
-        $this->assertAutocompleteMatches(
+        $this->assertSame(
             [
                 'nis-60000' => 'Provincie Luik',
                 'nis-62063' => 'Luik + deelgemeenten',
@@ -114,7 +114,7 @@ final class RegionServiceTest extends TestCase
      */
     public function it_will_match_with_informal_names(): void
     {
-        $this->assertAutocompleteMatches(
+        $this->assertSame(
             [
                 'nis-24008C' => 'Molenbeek-Wersbeek (Bekkevoort)',
                 'nis-21012' => 'Sint-Jans-Molenbeek + deelgemeenten',
@@ -147,15 +147,5 @@ final class RegionServiceTest extends TestCase
             null,
             $this->regionService->getItemByName('Liezele')
         );
-    }
-
-    /**
-     * First asserts that the keys and values of the two arrays are the same, and then asserts that the order of the
-     * values is as expected
-     */
-    private function assertAutocompleteMatches(array $expected, array $actual): void
-    {
-        $this->assertEquals($expected, $actual);
-        $this->assertEquals(array_values($expected), array_values($actual));
     }
 }

--- a/test/Widget/regions_sample.json
+++ b/test/Widget/regions_sample.json
@@ -236,10 +236,6 @@
     "key": "nis-60000"
   },
   {
-    "name": "Provincie Luik",
-    "key": "nis-60000"
-  },
-  {
     "name": "Luik + deelgemeenten",
     "key": "nis-62063"
   },

--- a/test/Widget/regions_sample.json
+++ b/test/Widget/regions_sample.json
@@ -230,5 +230,25 @@
   {
     "name":"Zelem (Halen)",
     "key":"nis-71020B"
+  },
+  {
+    "name": "Provincie Luik",
+    "key": "nis-60000"
+  },
+  {
+    "name": "Provincie Luik",
+    "key": "nis-60000"
+  },
+  {
+    "name": "Luik + deelgemeenten",
+    "key": "nis-62063"
+  },
+  {
+    "name": "Liège (Luik)",
+    "key": "nis-62063-Z"
+  },
+  {
+    "name": "Bressoux (Luik)",
+    "key": "nis-62063E"
   }
 ]


### PR DESCRIPTION
### Changed
- [Improve autocomplete results for provinces](https://github.com/cultuurnet/projectaanvraag-silex/commit/b9c7f489586319b85b7e2a860edcbc0440ee85d6)

A search on `vlaams-brabant` should return results e.g. `provincie vlaams-brabant`

---
Ticket: https://jira.publiq.be/browse/WID-588